### PR TITLE
Inference improvements on 0.7 and improvements in `show`

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -133,15 +133,13 @@ Base.fill(x, inds::Tuple{UnitRange,Vararg{UnitRange}}) =
 ### Low-level utilities ###
 
 # Computing a shifted index (subtracting the offset)
-@inline offset(offsets::NTuple{N,Int}, inds::NTuple{N,Int}) where {N} = _offset((), offsets, inds)
-_offset(out, ::Tuple{}, ::Tuple{}) = out
-@inline _offset(out, offsets, inds) =
-    _offset((out..., inds[1]-offsets[1]), Base.tail(offsets), Base.tail(inds))
+@inline offset(offsets::NTuple{N,Int}, inds::NTuple{N,Int}) where {N} =
+    (inds[1]-offsets[1], offset(Base.tail(offsets), Base.tail(inds))...)
+offset(::Tuple{}, ::Tuple{}) = ()
 
 # Support trailing 1s
 @inline offset(offsets::Tuple{Vararg{Int}}, inds::Tuple{Vararg{Int}}) =
     (offset(offsets, Base.front(inds))..., inds[end])
-offset(offsets::Tuple{}, inds::Tuple{}) = ()
 offset(offsets::Tuple{Vararg{Int}}, inds::Tuple{}) = error("inds cannot be shorter than offsets")
 
 indexoffset(r::AbstractRange) = first(r) - 1

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -219,4 +219,18 @@ end
 @inline unsafe_getindex(a::OffsetSubArray, I::Union{Integer,CartesianIndex}...) = unsafe_getindex(a, Base.IteratorsMD.flatten(I)...)
 @inline unsafe_setindex!(a::OffsetSubArray, val, I::Union{Integer,CartesianIndex}...) = unsafe_setindex!(a, val, Base.IteratorsMD.flatten(I)...)
 
+if VERSION >= v"0.7.0-DEV.1790"
+    function Base.showarg(io::IO, a::OffsetArray, toplevel)
+        print(io, "OffsetArray(")
+        Base.showarg(io, parent(a), false)
+        print(io, ", ")
+        printindices(io, indices(a)...)
+        print(io, ')')
+        toplevel && print(io, " with eltype ", eltype(a))
+    end
+    printindices(io::IO, ind1, inds...) =
+        (print(io, ind1, ", "); printindices(io, inds...))
+    printindices(io::IO, ind1) = print(io, ind1)
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ S = OffsetArray(view(A0, 1:2, 1:2), (-1,2))   # IndexCartesian
 @test_throws DimensionMismatch OffsetArray(A0, 0:1, 2:4)
 
 # Scalar indexing
-@test A[0,3] == A[0,3,1] == A[1] == S[0,3] == S[0,3,1] == S[1] == 1
+@test @inferred(A[0,3]) == @inferred(A[0,3,1]) == @inferred(A[1]) == @inferred(S[0,3]) == @inferred(S[0,3,1]) == @inferred(S[1]) == 1
 @test A[1,3] == A[1,3,1] == A[2] == S[1,3] == S[1,3,1] == S[2] == 2
 @test A[0,4] == A[0,4,1] == A[3] == S[0,4] == S[0,4,1] == S[3] == 3
 @test A[1,4] == A[1,4,1] == A[4] == S[1,4] == S[1,4,1] == S[4] == 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -353,3 +353,9 @@ for i = -3:3
     @test a[i] == i
 end
 @test unsafe_sum(a) == 0
+
+if VERSION >= v"0.7.0-DEV.1790"
+    a = OffsetArray([1 2; 3 4], -1:0, 5:6)
+    @test summary(a) == "OffsetArray(::Array{$(Int),2}, -1:0, 5:6) with eltype $(Int) with indices -1:0×5:6"
+    @test summary(view(a, :, 5)) == "view(OffsetArray(::Array{Int64,2}, -1:0, 5:6), :, 5) with eltype Int64 with indices -1:0"
+end


### PR DESCRIPTION
This does two things:
- fix an inference problem (will require https://github.com/JuliaLang/julia/pull/23867 to pass tests)
- leverage the new `showarg` functionality in Base to make `summary` easier to read. This was prototyped in ImageCore over the past 8 months; with it now in Base, it's time to migrate it into the respective packages.