### PR TITLE
deprecate constructors with type as first argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ like Fortran.
 ```julia
 julia> using OffsetArrays
 
-julia> y = OffsetArray(Float64, -1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1);
+julia> y = OffsetArray{Float64}(-1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1);
 
 julia> summary(y)
 "OffsetArrays.OffsetArray{Float64,8,Array{Float64,8}} with indices -1:1×-7:7×-128:512×-5:5×-1:1×-3:3×-2:2×-1:1"
@@ -117,11 +117,11 @@ Only the 2nd timing after warming up is given.
     Added
     + examples/scalar_law/PROGRAM1/...
 ```sh
-[~/w/m/O/e/s/PROGRAM1] $ julia linaddmain.jl --cells=10000 --runs=3                                                                           ms  master|✚ 1…  
+[~/w/m/O/e/s/PROGRAM1] $ julia linaddmain.jl --cells=10000 --runs=3                                                                           ms  master|✚ 1…
   0.672295 seconds (42.90 k allocations: 1.990 MB)
   0.509693 seconds (18 allocations: 313.281 KB)
   0.512243 seconds (18 allocations: 313.281 KB)
-[~/w/m/O/e/s/PROGRAM1] $ julia linaddmain.jl --cells=100000 --runs=3                                                                      6134ms  master|✚ 1…  
+[~/w/m/O/e/s/PROGRAM1] $ julia linaddmain.jl --cells=100000 --runs=3                                                                      6134ms  master|✚ 1…
   7.270463 seconds (42.90 k allocations: 4.736 MB)
   7.177485 seconds (18 allocations: 3.053 MB)
   7.248687 seconds (18 allocations: 3.053 MB)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -33,12 +33,14 @@ OffsetArray{T}(inds::Indices{N}) where {T,N} = OffsetArray{T,N}(inds)
 OffsetArray{T,N}(inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(inds)
 OffsetArray{T}(inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(inds)
 OffsetArray(A::AbstractArray{T,0}) where {T} = OffsetArray{T,0,typeof(A)}(A, ())
-OffsetArray(::Type{T}, inds::Vararg{UnitRange{Int},N}) where {T,N} = OffsetArray{T,N}(inds)
 
 # OffsetVector constructors
 OffsetVector(A::AbstractVector, offset) = OffsetArray(A, offset)
-OffsetVector(::Type{T}, inds::AbstractUnitRange) where {T} = OffsetArray{T,1}(inds)
 OffsetVector{T}(inds::AbstractUnitRange) where {T} = OffsetArray{T}(inds)
+
+# https://github.com/JuliaLang/julia/pull/19989
+Base.@deprecate OffsetArray(::Type{T}, inds::Vararg{UnitRange{Int},N}) where {T,N} OffsetArray{T}(inds)
+Base.@deprecate OffsetVector(::Type{T}, inds::AbstractUnitRange) where {T} OffsetVector{T}(inds)
 
 # The next two are necessary for ambiguity resolution. Really, the
 # second method should not be necessary.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,6 @@ using Compat.DelimitedFiles
 # Basics
 for n = 0:5
     for a in (OffsetArray(ones(Int,ntuple(d->1,n)), ntuple(x->x-1,n)),
-              fill!(OffsetArray(Float64, ntuple(x->x:x, n)...), 1),
               fill!(OffsetArray{Float64}(ntuple(x->x:x, n)), 1),
               fill!(OffsetArray{Float64}(ntuple(x->x:x, n)...), 1),
               fill!(OffsetArray{Float64,n}(ntuple(x->x:x, n)), 1),
@@ -24,7 +23,7 @@ a = OffsetArray(a0)
 @test ndims(a) == 0
 @test a[] == 3
 
-y = OffsetArray(Float64, -1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1)
+y = OffsetArray{Float64}(-1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1)
 @test axes(y) == (-1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1)
 y[-1,-7,-128,-5,-1,-3,-2,-1] = 14
 y[-1,-7,-128,-5,-1,-3,-2,-1] += 5
@@ -368,6 +367,5 @@ end
     local v = rand(5)
     @test OffsetVector(v, -2) == OffsetArray(v, -2)
     @test OffsetVector(v, -2:2) == OffsetArray(v, -2:2)
-    @test typeof(OffsetVector(Float64, -2:2)) == typeof(OffsetArray(Float64, -2:2))
     @test typeof(OffsetVector{Float64}(-2:2)) == typeof(OffsetArray{Float64}(-2:2))
 end


### PR DESCRIPTION
This type of `Array` constructors where deprecated in https://github.com/JuliaLang/julia/pull/19989, so `OffsetArrays` should do the same. Including the comma and the space, the replacement is even the same number of characters :smile: 