### PR TITLE
[WIP] fixes for julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.32
+Compat 0.45

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -4,6 +4,7 @@ module OffsetArrays
 
 using Base: Indices, tail
 using Compat
+using Compat: axes, CartesianIndices
 
 export OffsetArray, OffsetVector, @unsafe
 
@@ -27,7 +28,7 @@ OffsetArray(A::AbstractArray{T,N}, offsets::Vararg{Int,N}) where {T,N} =
     OffsetArray(A, offsets)
 
 OffsetArray{T,N}(inds::Indices{N}) where {T,N} =
-    OffsetArray{T,N,Array{T,N}}(Array{T,N}(map(length, inds)), map(indexoffset, inds))
+    OffsetArray{T,N,Array{T,N}}(Array{T,N}(uninitialized, map(length, inds)), map(indexoffset, inds))
 OffsetArray{T}(inds::Indices{N}) where {T,N} = OffsetArray{T,N}(inds)
 OffsetArray{T,N}(inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(inds)
 OffsetArray{T}(inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(inds)
@@ -44,9 +45,9 @@ OffsetVector{T}(inds::AbstractUnitRange) where {T} = OffsetArray{T}(inds)
 OffsetArray(A::AbstractArray{T,0}, inds::Tuple{}) where {T} = OffsetArray{T,0,typeof(A)}(A, ())
 OffsetArray(A::AbstractArray{T,N}, inds::Tuple{}) where {T,N} = error("this should never be called")
 function OffsetArray(A::AbstractArray{T,N}, inds::NTuple{N,AbstractUnitRange}) where {T,N}
-    lA = map(length, indices(A))
+    lA = map(length, axes(A))
     lI = map(length, inds)
-    lA == lI || throw(DimensionMismatch("supplied indices do not agree with the size of the array (got size $lA for the array and $lI for the indices"))
+    lA == lI || throw(DimensionMismatch("supplied axes do not agree with the size of the array (got size $lA for the array and $lI for the indices"))
     OffsetArray(A, map(indexoffset, inds))
 end
 OffsetArray(A::AbstractArray{T,N}, inds::Vararg{AbstractUnitRange,N}) where {T,N} =
@@ -58,22 +59,22 @@ parenttype(A::OffsetArray) = parenttype(typeof(A))
 
 Base.parent(A::OffsetArray) = A.parent
 
-errmsg(A) = error("size not supported for arrays with indices $(indices(A)); see http://docs.julialang.org/en/latest/devdocs/offset-arrays/")
+errmsg(A) = error("size not supported for arrays with axes $(axes(A)); see http://docs.julialang.org/en/latest/devdocs/offset-arrays/")
 Base.size(A::OffsetArray) = errmsg(A)
 Base.size(A::OffsetArray, d) = errmsg(A)
-Base.eachindex(::IndexCartesian, A::OffsetArray) = CartesianRange(indices(A))
-Base.eachindex(::IndexLinear, A::OffsetVector)   = indices(A, 1)
+Base.eachindex(::IndexCartesian, A::OffsetArray) = CartesianIndices(axes(A))
+Base.eachindex(::IndexLinear, A::OffsetVector)   = axes(A, 1)
 
-# Implementations of indices and indices1. Since bounds-checking is
-# performance-critical and relies on indices, these are usually worth
+# Implementations of axes and indices1. Since bounds-checking is
+# performance-critical and relies on axes, these are usually worth
 # optimizing thoroughly.
-@inline Base.indices(A::OffsetArray, d) =
-    1 <= d <= length(A.offsets) ? plus(indices(parent(A))[d], A.offsets[d]) : (1:1)
-@inline Base.indices(A::OffsetArray) =
-    _indices(indices(parent(A)), A.offsets)  # would rather use ntuple, but see #15276
-@inline _indices(inds, offsets) =
-    (plus(inds[1], offsets[1]), _indices(tail(inds), tail(offsets))...)
-_indices(::Tuple{}, ::Tuple{}) = ()
+@inline Compat.axes(A::OffsetArray, d) =
+    1 <= d <= length(A.offsets) ? plus(axes(parent(A))[d], A.offsets[d]) : (1:1)
+@inline Compat.axes(A::OffsetArray) =
+    _axes(axes(parent(A)), A.offsets)  # would rather use ntuple, but see #15276
+@inline _axes(inds, offsets) =
+    (plus(inds[1], offsets[1]), _axes(tail(inds), tail(offsets))...)
+_axes(::Tuple{}, ::Tuple{}) = ()
 Base.indices1(A::OffsetArray{T,0}) where {T} = 1:1  # we only need to specialize this one
 
 function Base.similar(A::OffsetArray, ::Type{T}, dims::Dims) where T
@@ -84,8 +85,14 @@ function Base.similar(A::AbstractArray, ::Type{T}, inds::Tuple{UnitRange,Vararg{
     OffsetArray(B, map(indexoffset, inds))
 end
 
-Base.similar(f::Union{Function,Type}, shape::Tuple{UnitRange,Vararg{UnitRange}}) =
+Base.similar(f::Function, shape::Tuple{UnitRange,Vararg{UnitRange}}) =
     OffsetArray(f(map(length, shape)), map(indexoffset, shape))
+Base.similar(::Type{T}, shape::Tuple{UnitRange,Vararg{UnitRange}}) where {T<:OffsetArray} =
+    OffsetArray(T(map(length, shape)), map(indexoffset, shape))
+Base.similar(::Type{T}, shape::Tuple{UnitRange,Vararg{UnitRange}}) where {T<:Array} =
+    OffsetArray(T(uninitialized, map(length, shape)), map(indexoffset, shape))
+Base.similar(::Type{T}, shape::Tuple{UnitRange,Vararg{UnitRange}}) where {T<:BitArray} =
+    OffsetArray(T(uninitialized, map(length, shape)), map(indexoffset, shape))
 
 Base.reshape(A::AbstractArray, inds::Tuple{UnitRange,Vararg{UnitRange}}) =
     OffsetArray(reshape(A, map(length, inds)), map(indexoffset, inds))
@@ -94,7 +101,7 @@ Base.reshape(A::OffsetArray, inds::Tuple{UnitRange,Vararg{UnitRange}}) =
     OffsetArray(reshape(parent(A), map(length, inds)), map(indexoffset, inds))
 
 function Base.reshape(A::OffsetArray, inds::Tuple{UnitRange,Vararg{Union{UnitRange,Int,Base.OneTo}}})
-    throw(ArgumentError("reshape must supply UnitRange indices, got $(typeof(inds)).\n       Note that reshape(A, Val{N}) is not supported for OffsetArrays."))
+    throw(ArgumentError("reshape must supply UnitRange axes, got $(typeof(inds)).\n       Note that reshape(A, Val{N}) is not supported for OffsetArrays."))
 end
 
 # Don't allow bounds-checks to be removed during Julia 0.5
@@ -198,20 +205,20 @@ end
     ret
 end
 @inline _unsafe_getindex(::IndexCartesian, a::OffsetArray, i::Int) =
-    unsafe_getindex(a, ind2sub(indices(a), i)...)
+    unsafe_getindex(a, CartesianIndices(axes(a))[i])
 @inline function _unsafe_setindex!(::IndexLinear, a::OffsetArray, val, i::Int)
     @inbounds parent(a)[i] = val
     val
 end
 @inline _unsafe_setindex!(::IndexCartesian, a::OffsetArray, val, i::Int) =
-    unsafe_setindex!(a, val, ind2sub(indices(a), i)...)
+    unsafe_setindex!(a, val, CartesianIndices(axes(a))[i]...)
 
 @inline unsafe_getindex(a::OffsetArray, I::Int...) = unsafe_getindex(parent(a), offset(a.offsets, I)...)
 @inline unsafe_setindex!(a::OffsetArray, val, I::Int...) = unsafe_setindex!(parent(a), val, offset(a.offsets, I)...)
 @inline unsafe_getindex(a::OffsetArray, I...) = unsafe_getindex(a, Base.IteratorsMD.flatten(I)...)
 @inline unsafe_setindex!(a::OffsetArray, val, I...) = unsafe_setindex!(a, val, Base.IteratorsMD.flatten(I)...)
 
-# Indexing a SubArray which has OffsetArray indices
+# Indexing a SubArray which has OffsetArray axes
 OffsetSubArray{T,N,P,I<:Tuple{OffsetArray,Vararg{OffsetArray}}} = SubArray{T,N,P,I,false}
 @inline function unsafe_getindex(a::OffsetSubArray{T,N}, I::Vararg{Int,N}) where {T,N}
     J = map(unsafe_getindex, a.indexes, I)
@@ -230,7 +237,7 @@ if VERSION >= v"0.7.0-DEV.1790"
         Base.showarg(io, parent(a), false)
         if ndims(a) > 0
             print(io, ", ")
-            printindices(io, indices(a)...)
+            printindices(io, axes(a)...)
         end
         print(io, ')')
         toplevel && print(io, " with eltype ", eltype(a))


### PR DESCRIPTION
Split out from #34: This PR aims to just get things working on julia master, and then I will rebase #34 on top of this.

So after investigating a bit further regarding the `similiar` methods discussed in #34 there seem to be two problems:

- With the new broadcasting interface, `broadcast_similar` used the fallback method. I fixed this by hooking into the broadcast machinery (excellent interface btw Tim :tada:)

- The other problems show up in the tests I commented out for now. For instance:
    ```julia
    julia> A = OffsetArray(rand(4,4), (-3,5));
    
    julia> unique(A, 1)
    ERROR: MethodError: no method matching Array{Int64,N} where N(::Uninitialized, ::Tuple{UnitRange{Int64}})
    Stacktrace:
     [1] similar(::Type{Array{Int64,N} where N}, ::Tuple{UnitRange{Int64}}) at ./array.jl:254
     [2] similar(::Type, ::UnitRange{Int64}) at ./abstractarray.jl:567
     [3] @generated body at ./multidimensional.jl:1583 [inlined]
     [4] unique(::OffsetArray{Float64,2,Array{Float64,2}}, ::Int64) at ./multidimensional.jl:1571
     [5] top-level scope
    ```

which is because `unique` calls the `similar(::Type{BitArray}, inds)` method here: https://github.com/JuliaLang/julia/blob/c697415e5d665e2085846dc3a3313cff296ef98f/base/multidimensional.jl#L1606 which forces us to hijack that method.

Similarly, for `sortcols` / `sortrows` we end up here: https://github.com/JuliaLang/julia/blob/c697415e5d665e2085846dc3a3313cff296ef98f/base/sort.jl#L964 which forces us to hijack that method. `sortcols` / `sortrows` can be fixed, *I think* with the following patch to base:
```diff
diff --git a/base/sort.jl b/base/sort.jl
index 2c7a0ac..ca7bbf6 100644
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -922,7 +922,7 @@ julia> sortrows([7 3 5; -1 6 4; 9 -2 8], rev=true)
 function sortrows(A::AbstractMatrix; kws...)
     inds = indices(A,1)
     T = slicetypeof(A, inds, :)
-    rows = similar(Vector{T}, indices(A, 1))
+    rows = similar(A, T, indices(A, 1))
     for i in inds
         rows[i] = view(A, i, :)
     end
@@ -961,7 +961,7 @@ julia> sortcols([7 3 5; 6 -1 -4; 9 -2 8], rev=true)
 function sortcols(A::AbstractMatrix; kws...)
     inds = indices(A,2)
     T = slicetypeof(A, :, inds)
-    cols = similar(Vector{T}, indices(A, 2))
+    cols = similar(A, T, indices(A, 2))
     for i in inds
         cols[i] = view(A, :, i)
     end
```