### PR TITLE
Make OffsetArray's axes offset themselves

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -289,8 +289,10 @@ if VERSION >= v"0.7.0-DEV.1790"
         toplevel && print(io, " with eltype ", eltype(a))
     end
     printindices(io::IO, ind1, inds...) =
-        (print(io, ind1, ", "); printindices(io, inds...))
-    printindices(io::IO, ind1) = print(io, ind1)
+        (print(io, _unslice(ind1), ", "); printindices(io, inds...))
+    printindices(io::IO, ind1) = print(io, _unslice(ind1))
+    _unslice(x) = x
+    _unslice(x::Base.Slice) = x.indices
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,18 +97,19 @@ Ac[0,3,1] = 11
 @test eachindex(S) == CartesianIndices(Base.Slice.((0:1,3:4)))
 
 # view
+const AxisType = VERSION < v"0.7.0-DEV.5242" ? identity : Base.Slice
 S = view(A, :, 3)
 @test S == OffsetArray([1,2], (A.offsets[1],))
 @test S[0] == 1
 @test S[1] == 2
 @test_throws BoundsError S[2]
-@test axes(S) === (Base.Slice(0:1),)
+@test axes(S) === (AxisType(0:1),)
 S = view(A, 0, :)
 @test S == OffsetArray([1,3], (A.offsets[2],))
 @test S[3] == 1
 @test S[4] == 3
 @test_throws BoundsError S[1]
-@test axes(S) === (Base.Slice(3:4),)
+@test axes(S) === (AxisType(3:4),)
 S = view(A, 0:0, 4)
 @test S == [3]
 @test S[1] == 3
@@ -127,7 +128,7 @@ S = view(A, :, :)
 @test S[0,4] == S[3] == 3
 @test S[1,4] == S[4] == 4
 @test_throws BoundsError S[1,1]
-@test axes(S) === Base.Slice.((0:1, 3:4))
+@test axes(S) === AxisType.((0:1, 3:4))
 
 # iteration
 let a
@@ -168,50 +169,53 @@ B = similar(A, (3,4))
 @test axes(B) === (Base.OneTo(3), Base.OneTo(4))
 B = similar(A, (-3:3,1:4))
 @test isa(B, OffsetArray{Int,2})
-@test axes(B) === Base.Slice.((-3:3, 1:4))
+@test axes(B) === AxisType.((-3:3, 1:4))
 B = similar(parent(A), (-3:3,1:4))
 @test isa(B, OffsetArray{Int,2})
-@test axes(B) === Base.Slice.((-3:3, 1:4))
+@test axes(B) === AxisType.((-3:3, 1:4))
 
 # Reshape
 B = reshape(A0, -10:-9, 9:10)
 @test isa(B, OffsetArray{Int,2})
 @test parent(B) === A0
-@test axes(B) == Base.Slice.((-10:-9, 9:10))
+@test axes(B) == AxisType.((-10:-9, 9:10))
 B = reshape(A, -10:-9, 9:10)
 @test isa(B, OffsetArray{Int,2})
 @test pointer(parent(B)) === pointer(A0)
-@test axes(B) == Base.Slice.((-10:-9, 9:10))
+@test axes(B) == AxisType.((-10:-9, 9:10))
 b = reshape(A, -7:-4)
-@test axes(b) == (Base.Slice(-7:-4),)
+@test axes(b) == (AxisType(-7:-4),)
 @test isa(parent(b), Vector{Int})
 @test pointer(parent(b)) === pointer(parent(A))
 @test parent(b) == A0[:]
 a = OffsetArray(rand(3,3,3), -1:1, 0:2, 3:5)
+if VERSION >= v"0.7.0-DEV.5242"
+# Offset axes are required for reshape(::OffsetArray, ::Val) support
 b = reshape(a, Val(2))
 @test isa(b, OffsetArray{Float64,2})
 @test pointer(parent(b)) === pointer(parent(a))
-@test axes(b) == Base.Slice.((-1:1, 1:9))
+@test axes(b) == AxisType.((-1:1, 1:9))
 b = reshape(a, Val(4))
 @test isa(b, OffsetArray{Float64,4})
 @test pointer(parent(b)) === pointer(parent(a))
-@test axes(b) == (axes(a)..., Base.Slice(1:1))
+@test axes(b) == (axes(a)..., AxisType(1:1))
+end
 
 # Indexing with OffsetArray axes
 i1 = OffsetArray([2,1], (-5,))
 i1 = OffsetArray([2,1], -5)
 b = A0[i1, 1]
-@test axes(b) === (Base.Slice(-4:-3),)
+@test axes(b) === (AxisType(-4:-3),)
 @test b[-4] == 2
 @test b[-3] == 1
 b = A0[1,i1]
-@test axes(b) === (Base.Slice(-4:-3),)
+@test axes(b) === (AxisType(-4:-3),)
 @test b[-4] == 3
 @test b[-3] == 1
 v = view(A0, i1, 1)
-@test axes(v) === (Base.Slice(-4:-3),)
+@test axes(v) === (AxisType(-4:-3),)
 v = view(A0, 1:1, i1)
-@test axes(v) === (Base.OneTo(1), Base.Slice(-4:-3))
+@test axes(v) === (Base.OneTo(1), AxisType(-4:-3))
 
 # logical indexing
 @test A[A .> 2] == [3,4]
@@ -321,8 +325,10 @@ seek(io, 0)
 amin, amax = extrema(parent(A))
 @test clamp.(A, (amax+amin)/2, amax) == OffsetArray(clamp.(parent(A), (amax+amin)/2, amax), axes(A))
 
+if VERSION >= v"0.7.0-DEV.5242"
 @test unique(A, 1) == OffsetArray(parent(A), 0, first(axes(A, 2)) - 1)
 @test unique(A, 2) == OffsetArray(parent(A), first(axes(A, 1)) - 1, 0)
+end
 v = OffsetArray(rand(8), (-2,))
 @test sort(v) == OffsetArray(sort(parent(v)), v.offsets)
 @test sortrows(A) == OffsetArray(sortrows(parent(A)), A.offsets)


### PR DESCRIPTION
This is largely an advertisement for JuliaLang/julia#27038 — let's focus the discussion there.  This implements the new scheme proposed there.  Only one failure remains locally with that branch regarding the display of the axes in `summary` since they're now `Slice`s.