### PR TITLE
Require julia 0.7-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
     - linux
 
 julia:
-    - 0.6
     - nightly
 
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6
-Compat 0.45
+julia 0.7.0-beta.73

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -18,7 +18,7 @@ OffsetArray(A::AbstractArray{T,N}, offsets::Vararg{Int,N}) where {T,N} =
     OffsetArray(A, offsets)
 
 OffsetArray{T,N}(::UndefInitializer, inds::Indices{N}) where {T,N} =
-    OffsetArray{T,N,Array{T,N}}(Array{T,N}(undef, map(length, inds)), map(indexoffset, inds))
+    OffsetArray{T,N,Array{T,N}}(Array{T,N}(undef, map(indexlength, inds)), map(indexoffset, inds))
 OffsetArray{T}(::UndefInitializer, inds::Indices{N}) where {T,N} = OffsetArray{T,N}(undef, inds)
 OffsetArray{T,N}(::UndefInitializer, inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(undef, inds)
 OffsetArray{T}(::UndefInitializer, inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(undef, inds)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -3,21 +3,8 @@ __precompile__()
 module OffsetArrays
 
 using Base: Indices, tail
-using Compat
-using Compat: axes, CartesianIndices
 
 export OffsetArray, OffsetVector, @unsafe
-
-## Major change in 0.7: OffsetArray now uses Offset axes
-const AxisType = VERSION < v"0.7.0-DEV.5242" ? identity : Base.Slice
-
-# TODO: just use .+
-# See https://github.com/JuliaLang/julia/pull/22932#issuecomment-330711997
-if VERSION < v"0.7.0-DEV.1759"
-    plus(r::AbstractUnitRange, i::Integer) = r + i
-else
-    plus(r::AbstractUnitRange, i::Integer) = broadcast(+, r, i)
-end
 
 struct OffsetArray{T,N,AA<:AbstractArray} <: AbstractArray{T,N}
     parent::AA
@@ -44,33 +31,13 @@ OffsetVector{T}(::UndefInitializer, inds::AbstractUnitRange) where {T} = OffsetA
 # deprecated constructors
 using Base: @deprecate
 
-# https://github.com/JuliaLang/julia/pull/19989
-@static if isdefined(Base, :UndefInitializer)
-    @deprecate OffsetArray(::Type{T}, inds::Vararg{UnitRange{Int},N}) where {T,N} OffsetArray{T}(undef, inds)
-    @deprecate OffsetVector(::Type{T}, inds::AbstractUnitRange) where {T} OffsetVector{T}(undef, inds)
-else
-    OffsetArray(::Type{T}, inds::Vararg{UnitRange{Int},N}) where {T,N} = OffsetArray{T}(inds)
-    OffsetVector(::Type{T}, inds::AbstractUnitRange) where {T} = OffsetVector{T}(inds)
-end
-
-# https://github.com/JuliaLang/julia/pull/24652
-# Only activate deprecation if `undef` is available from Base;
-# should not rely on the user having `undef` available from Compat
-# and OffsetArrays.jl should probably not re-export Compat.undef
-@static if isdefined(Base, :UndefInitializer)
-    @deprecate OffsetArray{T,N}(inds::Indices{N}) where {T,N} OffsetArray{T,N}(undef, inds)
-    @deprecate OffsetArray{T}(inds::Indices{N}) where {T,N} OffsetArray{T}(undef, inds)
-    @deprecate OffsetArray{T,N}(inds::Vararg{AbstractUnitRange,N}) where {T,N} OffsetArray{T,N}(undef, inds)
-    @deprecate OffsetArray{T}(inds::Vararg{AbstractUnitRange,N}) where {T,N} OffsetArray{T}(undef, inds)
-    @deprecate OffsetVector{T}(inds::AbstractUnitRange) where {T} OffsetVector{T}(undef, inds)
-else
-    OffsetArray{T,N}(inds::Indices{N}) where {T,N} = OffsetArray{T,N}(undef, inds)
-    OffsetArray{T}(inds::Indices{N}) where {T,N} = OffsetArray{T}(undef, inds)
-    OffsetArray{T,N}(inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(undef, inds)
-    OffsetArray{T}(inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T}(undef, inds)
-    OffsetVector{T}(inds::AbstractUnitRange) where {T} = OffsetVector{T}(undef, inds)
-end
-
+@deprecate OffsetArray(::Type{T}, inds::Vararg{UnitRange{Int},N}) where {T,N} OffsetArray{T}(undef, inds)
+@deprecate OffsetVector(::Type{T}, inds::AbstractUnitRange) where {T} OffsetVector{T}(undef, inds)
+@deprecate OffsetArray{T,N}(inds::Indices{N}) where {T,N} OffsetArray{T,N}(undef, inds)
+@deprecate OffsetArray{T}(inds::Indices{N}) where {T,N} OffsetArray{T}(undef, inds)
+@deprecate OffsetArray{T,N}(inds::Vararg{AbstractUnitRange,N}) where {T,N} OffsetArray{T,N}(undef, inds)
+@deprecate OffsetArray{T}(inds::Vararg{AbstractUnitRange,N}) where {T,N} OffsetArray{T}(undef, inds)
+@deprecate OffsetVector{T}(inds::AbstractUnitRange) where {T} OffsetVector{T}(undef, inds)
 
 # The next two are necessary for ambiguity resolution. Really, the
 # second method should not be necessary.
@@ -100,12 +67,12 @@ Base.eachindex(::IndexLinear, A::OffsetVector)   = axes(A, 1)
 # Implementations of axes and indices1. Since bounds-checking is
 # performance-critical and relies on axes, these are usually worth
 # optimizing thoroughly.
-@inline Compat.axes(A::OffsetArray, d) =
-    1 <= d <= length(A.offsets) ? AxisType(plus(axes(parent(A))[d], A.offsets[d])) : (1:1)
-@inline Compat.axes(A::OffsetArray) =
+@inline Base.axes(A::OffsetArray, d) =
+    1 <= d <= length(A.offsets) ? Base.Slice(axes(parent(A))[d] .+ A.offsets[d]) : (1:1)
+@inline Base.axes(A::OffsetArray) =
     _axes(axes(parent(A)), A.offsets)  # would rather use ntuple, but see #15276
 @inline _axes(inds, offsets) =
-    (AxisType(plus(inds[1], offsets[1])), _axes(tail(inds), tail(offsets))...)
+    (Base.Slice(inds[1] .+ offsets[1]), _axes(tail(inds), tail(offsets))...)
 _axes(::Tuple{}, ::Tuple{}) = ()
 Base.indices1(A::OffsetArray{T,0}) where {T} = 1:1  # we only need to specialize this one
 
@@ -119,16 +86,6 @@ function Base.similar(A::AbstractArray, ::Type{T}, inds::Tuple{OffsetAxis,Vararg
     OffsetArray(B, map(indexoffset, inds))
 end
 
-if VERSION < v"0.7.0-DEV.5242"
-# Reshape's methods in Base changed, so using the new definitions leads to ambiguities
-Base.reshape(A::AbstractArray, inds::Tuple{UnitRange,Vararg{UnitRange}}) =
-    OffsetArray(reshape(A, map(length, inds)), map(indexoffset, inds))
-Base.reshape(A::OffsetArray, inds::Tuple{UnitRange,Vararg{UnitRange}}) =
-    OffsetArray(reshape(parent(A), map(length, inds)), map(indexoffset, inds))
-function Base.reshape(A::OffsetArray, inds::Tuple{UnitRange,Vararg{Union{UnitRange,Int,Base.OneTo}}})
-    throw(ArgumentError("reshape must supply UnitRange axes, got $(typeof(inds)).\n       Note that reshape(A, Val{N}) is not supported for OffsetArrays."))
-end
-else
 Base.reshape(A::AbstractArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}}) =
     OffsetArray(reshape(A, map(indexlength, inds)), map(indexoffset, inds))
 
@@ -139,30 +96,20 @@ Base.reshape(A::OffsetArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}}) =
 # And for non-offset axes, we can just return a reshape of the parent directly
 Base.reshape(A::OffsetArray, inds::Tuple{Union{Integer,Base.OneTo},Vararg{Union{Integer,Base.OneTo}}}) = reshape(parent(A), inds)
 Base.reshape(A::OffsetArray, inds::Dims) = reshape(parent(A), inds)
-end
 
-if VERSION < v"0.7.0-DEV.4873"
-    # Julia PR #26733 removed similar(f, ...) in favor of just using method extension directly
-    # https://github.com/JuliaLang/julia/pull/26733
-    Base.similar(::Type{T}, shape::Tuple{UnitRange,Vararg{UnitRange}}) where {T<:AbstractArray} =
-        OffsetArray(T(undef, map(indexlength, shape)), map(indexoffset, shape))
-    Base.similar(f::Function, shape::Tuple{UnitRange,Vararg{UnitRange}}) =
-        OffsetArray(f(map(indexlength, shape)), map(indexoffset, shape))
-else
-    Base.similar(::Type{T}, shape::Tuple{OffsetAxis,Vararg{OffsetAxis}}) where {T<:AbstractArray} =
-        OffsetArray(T(undef, map(indexlength, shape)), map(indexoffset, shape))
+Base.similar(::Type{T}, shape::Tuple{OffsetAxis,Vararg{OffsetAxis}}) where {T<:AbstractArray} =
+    OffsetArray(T(undef, map(indexlength, shape)), map(indexoffset, shape))
 
-    Base.fill(v, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-        fill!(OffsetArray(Array{typeof(v), N}(undef, map(indexlength, inds)), map(indexoffset, inds)), v)
-    Base.zeros(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
-        fill!(OffsetArray(Array{T, N}(undef, map(indexlength, inds)), map(indexoffset, inds)), zero(T))
-    Base.ones(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
-        fill!(OffsetArray(Array{T, N}(undef, map(indexlength, inds)), map(indexoffset, inds)), one(T))
-    Base.trues(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-        fill!(OffsetArray(BitArray{N}(undef, map(indexlength, inds)), map(indexoffset, inds)), true)
-    Base.falses(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-        fill!(OffsetArray(BitArray{N}(undef, map(indexlength, inds)), map(indexoffset, inds)), false)
-end
+Base.fill(v, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
+    fill!(OffsetArray(Array{typeof(v), N}(undef, map(indexlength, inds)), map(indexoffset, inds)), v)
+Base.zeros(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
+    fill!(OffsetArray(Array{T, N}(undef, map(indexlength, inds)), map(indexoffset, inds)), zero(T))
+Base.ones(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
+    fill!(OffsetArray(Array{T, N}(undef, map(indexlength, inds)), map(indexoffset, inds)), one(T))
+Base.trues(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
+    fill!(OffsetArray(BitArray{N}(undef, map(indexlength, inds)), map(indexoffset, inds)), true)
+Base.falses(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
+    fill!(OffsetArray(BitArray{N}(undef, map(indexlength, inds)), map(indexoffset, inds)), false)
 
 # Don't allow bounds-checks to be removed during Julia 0.5
 @inline function Base.getindex(A::OffsetArray{T,N}, I::Vararg{Int,N}) where {T,N}
@@ -293,22 +240,20 @@ end
 @inline unsafe_getindex(a::OffsetSubArray, I::Union{Integer,CartesianIndex}...) = unsafe_getindex(a, Base.IteratorsMD.flatten(I)...)
 @inline unsafe_setindex!(a::OffsetSubArray, val, I::Union{Integer,CartesianIndex}...) = unsafe_setindex!(a, val, Base.IteratorsMD.flatten(I)...)
 
-if VERSION >= v"0.7.0-DEV.1790"
-    function Base.showarg(io::IO, a::OffsetArray, toplevel)
-        print(io, "OffsetArray(")
-        Base.showarg(io, parent(a), false)
-        if ndims(a) > 0
-            print(io, ", ")
-            printindices(io, axes(a)...)
-        end
-        print(io, ')')
-        toplevel && print(io, " with eltype ", eltype(a))
+function Base.showarg(io::IO, a::OffsetArray, toplevel)
+    print(io, "OffsetArray(")
+    Base.showarg(io, parent(a), false)
+    if ndims(a) > 0
+        print(io, ", ")
+        printindices(io, axes(a)...)
     end
-    printindices(io::IO, ind1, inds...) =
-        (print(io, _unslice(ind1), ", "); printindices(io, inds...))
-    printindices(io::IO, ind1) = print(io, _unslice(ind1))
-    _unslice(x) = x
-    _unslice(x::Base.Slice) = x.indices
+    print(io, ')')
+    toplevel && print(io, " with eltype ", eltype(a))
 end
+printindices(io::IO, ind1, inds...) =
+    (print(io, _unslice(ind1), ", "); printindices(io, inds...))
+printindices(io::IO, ind1) = print(io, _unslice(ind1))
+_unslice(x) = x
+_unslice(x::Base.Slice) = x.indices
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,9 @@ y = OffsetArray(r, r)
 y = OffsetArray(r, (r,))
 @test axes(y) == (r,)
 
+y = OffsetArray{Float32}(undef, (Base.Slice(-1:1),))
+@test axes(y) === (Base.Slice(-1:1),)
+
 A0 = [1 3; 2 4]
 A = OffsetArray(A0, (-1,2))                   # IndexLinear
 S = OffsetArray(view(A0, 1:2, 1:2), (-1,2))   # IndexCartesian

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,6 @@
-using Compat.Test
 using OffsetArrays
-using Compat
-using Compat: axes, CartesianIndices, copyto!
-using Compat.DelimitedFiles
+using Test
+using DelimitedFiles
 
 @test isempty(detect_ambiguities(OffsetArrays, Base, Core))
 
@@ -97,19 +95,18 @@ Ac[0,3,1] = 11
 @test eachindex(S) == CartesianIndices(Base.Slice.((0:1,3:4)))
 
 # view
-const AxisType = VERSION < v"0.7.0-DEV.5242" ? identity : Base.Slice
 S = view(A, :, 3)
 @test S == OffsetArray([1,2], (A.offsets[1],))
 @test S[0] == 1
 @test S[1] == 2
 @test_throws BoundsError S[2]
-@test axes(S) === (AxisType(0:1),)
+@test axes(S) === (Base.Slice(0:1),)
 S = view(A, 0, :)
 @test S == OffsetArray([1,3], (A.offsets[2],))
 @test S[3] == 1
 @test S[4] == 3
 @test_throws BoundsError S[1]
-@test axes(S) === (AxisType(3:4),)
+@test axes(S) === (Base.Slice(3:4),)
 S = view(A, 0:0, 4)
 @test S == [3]
 @test S[1] == 3
@@ -128,7 +125,7 @@ S = view(A, :, :)
 @test S[0,4] == S[3] == 3
 @test S[1,4] == S[4] == 4
 @test_throws BoundsError S[1,1]
-@test axes(S) === AxisType.((0:1, 3:4))
+@test axes(S) === Base.Slice.((0:1, 3:4))
 
 # iteration
 let a
@@ -169,10 +166,10 @@ B = similar(A, (3,4))
 @test axes(B) === (Base.OneTo(3), Base.OneTo(4))
 B = similar(A, (-3:3,1:4))
 @test isa(B, OffsetArray{Int,2})
-@test axes(B) === AxisType.((-3:3, 1:4))
+@test axes(B) === Base.Slice.((-3:3, 1:4))
 B = similar(parent(A), (-3:3,1:4))
 @test isa(B, OffsetArray{Int,2})
-@test axes(B) === AxisType.((-3:3, 1:4))
+@test axes(B) === Base.Slice.((-3:3, 1:4))
 @test isa([x for x in [1,2,3]], Vector{Int})
 @test similar(Array{Int}, (0:0, 0:0)) isa OffsetArray{Int, 2}
 @test similar(Array{Int}, (1, 1)) isa Matrix{Int}
@@ -185,13 +182,13 @@ end
 B = reshape(A0, -10:-9, 9:10)
 @test isa(B, OffsetArray{Int,2})
 @test parent(B) === A0
-@test axes(B) == AxisType.((-10:-9, 9:10))
+@test axes(B) == Base.Slice.((-10:-9, 9:10))
 B = reshape(A, -10:-9, 9:10)
 @test isa(B, OffsetArray{Int,2})
 @test pointer(parent(B)) === pointer(A0)
-@test axes(B) == AxisType.((-10:-9, 9:10))
+@test axes(B) == Base.Slice.((-10:-9, 9:10))
 b = reshape(A, -7:-4)
-@test axes(b) == (AxisType(-7:-4),)
+@test axes(b) == (Base.Slice(-7:-4),)
 @test isa(parent(b), Vector{Int})
 @test pointer(parent(b)) === pointer(parent(A))
 @test parent(b) == A0[:]
@@ -201,28 +198,28 @@ if VERSION >= v"0.7.0-DEV.5242"
 b = reshape(a, Val(2))
 @test isa(b, OffsetArray{Float64,2})
 @test pointer(parent(b)) === pointer(parent(a))
-@test axes(b) == AxisType.((-1:1, 1:9))
+@test axes(b) == Base.Slice.((-1:1, 1:9))
 b = reshape(a, Val(4))
 @test isa(b, OffsetArray{Float64,4})
 @test pointer(parent(b)) === pointer(parent(a))
-@test axes(b) == (axes(a)..., AxisType(1:1))
+@test axes(b) == (axes(a)..., Base.Slice(1:1))
 end
 
 # Indexing with OffsetArray axes
 i1 = OffsetArray([2,1], (-5,))
 i1 = OffsetArray([2,1], -5)
 b = A0[i1, 1]
-@test axes(b) === (AxisType(-4:-3),)
+@test axes(b) === (Base.Slice(-4:-3),)
 @test b[-4] == 2
 @test b[-3] == 1
 b = A0[1,i1]
-@test axes(b) === (AxisType(-4:-3),)
+@test axes(b) === (Base.Slice(-4:-3),)
 @test b[-4] == 3
 @test b[-3] == 1
 v = view(A0, i1, 1)
-@test axes(v) === (AxisType(-4:-3),)
+@test axes(v) === (Base.Slice(-4:-3),)
 v = view(A0, 1:1, i1)
-@test axes(v) === (Base.OneTo(1), AxisType(-4:-3))
+@test axes(v) === (Base.OneTo(1), Base.Slice(-4:-3))
 
 # logical indexing
 @test A[A .> 2] == [3,4]
@@ -293,17 +290,17 @@ A = OffsetArray(rand(4,4), (-3,5))
 @test minimum(A) == minimum(parent(A))
 @test extrema(A) == extrema(parent(A))
 C = similar(A)
-Compat.cumsum!(C, A, dims = 1)
-@test parent(C) == Compat.cumsum(parent(A), dims = 1)
-@test parent(Compat.cumsum(A, dims = 1)) == Compat.cumsum(parent(A), dims = 1)
-Compat.cumsum!(C, A, dims = 2)
-@test parent(C) == Compat.cumsum(parent(A), dims = 2)
+cumsum!(C, A, dims = 1)
+@test parent(C) == cumsum(parent(A), dims = 1)
+@test parent(cumsum(A, dims = 1)) == cumsum(parent(A), dims = 1)
+cumsum!(C, A, dims = 2)
+@test parent(C) == cumsum(parent(A), dims = 2)
 R = similar(A, (1:1, 6:9))
 maximum!(R, A)
-@test parent(R) == Compat.maximum(parent(A), dims = 1)
+@test parent(R) == maximum(parent(A), dims = 1)
 R = similar(A, (-2:1, 1:1))
 maximum!(R, A)
-@test parent(R) == Compat.maximum(parent(A), dims = 2)
+@test parent(R) == maximum(parent(A), dims = 2)
 amin, iamin = findmin(A)
 pmin, ipmin = findmin(parent(A))
 @test amin == pmin
@@ -340,16 +337,16 @@ v = OffsetArray(rand(8), (-2,))
 @test sort(v) == OffsetArray(sort(parent(v)), v.offsets)
 @test sortrows(A) == OffsetArray(sortrows(parent(A)), A.offsets)
 @test sortcols(A) == OffsetArray(sortcols(parent(A)), A.offsets)
-@test Compat.sort(A, dims = 1) == OffsetArray(Compat.sort(parent(A), dims = 1), A.offsets)
-@test Compat.sort(A, dims = 2) == OffsetArray(Compat.sort(parent(A), dims = 2), A.offsets)
+@test sort(A, dims = 1) == OffsetArray(sort(parent(A), dims = 1), A.offsets)
+@test sort(A, dims = 2) == OffsetArray(sort(parent(A), dims = 2), A.offsets)
 
-@test mapslices(v->sort(v), A, 1) == OffsetArray(mapslices(v->sort(v), parent(A), 1), A.offsets)
-@test mapslices(v->sort(v), A, 2) == OffsetArray(mapslices(v->sort(v), parent(A), 2), A.offsets)
+@test mapslices(v->sort(v), A, dims = 1) == OffsetArray(mapslices(v->sort(v), parent(A), dims = 1), A.offsets)
+@test mapslices(v->sort(v), A, dims = 2) == OffsetArray(mapslices(v->sort(v), parent(A), dims = 2), A.offsets)
 
 @test rotl90(A) == OffsetArray(rotl90(parent(A)), A.offsets[[2,1]])
 @test rotr90(A) == OffsetArray(rotr90(parent(A)), A.offsets[[2,1]])
-@test Compat.reverse(A, dims = 1) == OffsetArray(Compat.reverse(parent(A), dims = 1), A.offsets)
-@test Compat.reverse(A, dims = 2) == OffsetArray(Compat.reverse(parent(A), dims = 2), A.offsets)
+@test reverse(A, dims = 1) == OffsetArray(reverse(parent(A), dims = 1), A.offsets)
+@test reverse(A, dims = 2) == OffsetArray(reverse(parent(A), dims = 2), A.offsets)
 
 @test A.+1 == OffsetArray(parent(A).+1, A.offsets)
 @test 2*A == OffsetArray(2*parent(A), A.offsets)


### PR DESCRIPTION
This fixes some new deprecations (e.g., `mapslices`), but mostly it removes version cruft and commits to the new Julia.