### PR TITLE
Added resize! function for OffsetVector

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -147,6 +147,8 @@ Base.fill(x, inds::Tuple{UnitRange,Vararg{UnitRange}}) =
     fill!(OffsetArray{typeof(x)}(undef, inds), x)
 @inline Base.fill(x, ind1::UnitRange, inds::UnitRange...) = fill(x, (ind1, inds...))
 
+Base.resize!(A::OffsetVector, nl::Integer) = (resize!(A.parent, nl); A)
+
 ### Low-level utilities ###
 
 # Computing a shifted index (subtracting the offset)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -376,6 +376,16 @@ a = OffsetArray([1 2; 3 4], -1:0, 5:6)
 a = OffsetArray(reshape([1]))
 @test summary(a) == "0-dimensional OffsetArray(::Array{$(Int),0}) with eltype $(Int)"
 
+@testset "Resizing OffsetVectors" begin
+    local a = OffsetVector(rand(5),-3)
+    axes(a,1) == -2:2
+    length(a) == 5
+    resize!(a,3)
+    length(a) == 3
+    axes(a,1) == -2:0
+    @test_throws ArgumentError resize!(a,-3)
+end
+
 @testset "OffsetVector constructors" begin
     local v = rand(5)
     @test OffsetVector(v, -2) == OffsetArray(v, -2)


### PR DESCRIPTION
This pull request implements resizing for OffsetVectors.

The code was taken from julia/test/testhelpers/OffsetArrays.jl and by including it, unique!() should subsequently also work for OffsetArrays.

