### PR TITLE
Add OffsetArray/OffsetVector constructors for missing and nothing initialization

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -17,16 +17,17 @@ OffsetArray(A::AbstractArray{T,N}, offsets::NTuple{N,Int}) where {T,N} =
 OffsetArray(A::AbstractArray{T,N}, offsets::Vararg{Int,N}) where {T,N} =
     OffsetArray(A, offsets)
 
-OffsetArray{T,N}(::UndefInitializer, inds::Indices{N}) where {T,N} =
-    OffsetArray{T,N,Array{T,N}}(Array{T,N}(undef, map(indexlength, inds)), map(indexoffset, inds))
-OffsetArray{T}(::UndefInitializer, inds::Indices{N}) where {T,N} = OffsetArray{T,N}(undef, inds)
-OffsetArray{T,N}(::UndefInitializer, inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(undef, inds)
-OffsetArray{T}(::UndefInitializer, inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(undef, inds)
+const ArrayInitializer = Union{UndefInitializer, Missing, Nothing}
+OffsetArray{T,N}(init::ArrayInitializer, inds::Indices{N}) where {T,N} =
+    OffsetArray{T,N,Array{T,N}}(Array{T,N}(init, map(indexlength, inds)), map(indexoffset, inds))
+OffsetArray{T}(init::ArrayInitializer, inds::Indices{N}) where {T,N} = OffsetArray{T,N}(init, inds)
+OffsetArray{T,N}(init::ArrayInitializer, inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(init, inds)
+OffsetArray{T}(init::ArrayInitializer, inds::Vararg{AbstractUnitRange,N}) where {T,N} = OffsetArray{T,N}(init, inds)
 OffsetArray(A::AbstractArray{T,0}) where {T} = OffsetArray{T,0,typeof(A)}(A, ())
 
 # OffsetVector constructors
 OffsetVector(A::AbstractVector, offset) = OffsetArray(A, offset)
-OffsetVector{T}(::UndefInitializer, inds::AbstractUnitRange) where {T} = OffsetArray{T}(undef, inds)
+OffsetVector{T}(init::ArrayInitializer, inds::AbstractUnitRange) where {T} = OffsetArray{T}(init, inds)
 
 # deprecated constructors
 using Base: @deprecate

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,14 @@ a = OffsetArray(a0)
 @test ndims(a) == 0
 @test a[] == 3
 
+# missing and nothing constructors
+for (T, t) in ((Missing, missing), (Nothing, nothing))
+    @test !isassigned(OffsetArray{Union{T,Vector{Int}}}(undef, -1:1, -1:1), -1, -1)
+    @test OffsetArray{Union{T,Vector{Int}}}(t, -1:1, -1:1)[-1, -1] === t
+    @test !isassigned(OffsetVector{Union{T,Vector{Int}}}(undef, -1:1), -1)
+    @test OffsetVector{Union{T,Vector{Int}}}(t, -1:1)[-1] === t
+end
+
 y = OffsetArray{Float64}(undef, -1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1)
 @test axes(y) == (-1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1)
 y[-1,-7,-128,-5,-1,-3,-2,-1] = 14


### PR DESCRIPTION
Inspired by https://github.com/JuliaLang/julia/blob/9eda36ffa1aa96ddf0ecac3add1144fafc4f9cc9/base/sysimg.jl#L159. I think this implementation with the union type `ArrayInitializer` is a little more compact and should be exactly equivalent to explicitly writing out cases for `UndefInitializer`, `Nothing`, and `Missing` as in the base implementation above, but I could be wrong about the "exactly equivalent" statement -- let me know if you'd prefer the "unrolled" version.