### PR TITLE
Add no_offset_view

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -193,4 +193,39 @@ printindices(io::IO, ind1) = print(io, _unslice(ind1))
 _unslice(x) = x
 _unslice(x::IdentityUnitRange) = x.indices
 
+"""
+    no_offset_view(A)
+
+Return an `AbstractArray` that shares structure and has the same type and size as the
+argument, but has 1-based indexing. May just return the argument when applicable. Not
+exported.
+
+The default implementation uses `OffsetArrays`, but other types should use something more
+specific to remove a level of indirection when applicable.
+
+```jldoctest
+julia> O = OffsetArray(A, 0:1, -1:1)
+OffsetArray(::Array{Int64,2}, 0:1, -1:1) with eltype Int64 with indices 0:1×-1:1:
+ 1  3  5
+ 2  4  6
+
+julia> OffsetArrays.no_offset_view(O)[1,1] = -9
+-9
+
+julia> A
+2×3 Array{Int64,2}:
+ -9  3  5
+  2  4  6
+```
+"""
+function no_offset_view(A::AbstractArray{T,N}) where {T,N}
+    if Base.has_offset_axes(A)
+        OffsetArray{T}(A, ntuple(i -> firstindex(A, i):lastindex(A, i), N))
+    else
+        A
+    end
+end
+
+no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
+
 end # module

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -218,9 +218,9 @@ julia> A
   2  4  6
 ```
 """
-function no_offset_view(A::AbstractArray{T,N}) where {T,N}
+function no_offset_view(A::AbstractArray)
     if Base.has_offset_axes(A)
-        OffsetArray{T}(A, ntuple(i -> firstindex(A, i):lastindex(A, i), N))
+        OffsetArray(A, 1 .+ size(A))
     else
         A
     end

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -220,7 +220,7 @@ julia> A
 """
 function no_offset_view(A::AbstractArray)
     if Base.has_offset_axes(A)
-        OffsetArray(A, 1 .+ size(A))
+        OffsetArray(A, map(r->1-first(r), axes(A)))
     else
         A
     end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+CatIndices

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using OffsetArrays
 using Test
 using DelimitedFiles
-using OffsetArrays: IdentityUnitRange
+using OffsetArrays: IdentityUnitRange, no_offset_view
 
 @test isempty(detect_ambiguities(OffsetArrays, Base, Core))
 
@@ -400,4 +400,11 @@ end
     @test OffsetVector(v, -2) == OffsetArray(v, -2)
     @test OffsetVector(v, -2:2) == OffsetArray(v, -2:2)
     @test typeof(OffsetVector{Float64}(undef, -2:2)) == typeof(OffsetArray{Float64}(undef, -2:2))
+end
+
+@testset "no offset view" begin
+    A = randn(3, 3)
+    O1 = OffsetArray(A, -1:1, 0:2)
+    O2 = OffsetArray(O1, -2:0, -3:(-1))
+    @test no_offset_view(O2) ≡ A
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using OffsetArrays
 using Test
 using DelimitedFiles
 using OffsetArrays: IdentityUnitRange, no_offset_view
+using CatIndices: BidirectionalVector
 
 @test isempty(detect_ambiguities(OffsetArrays, Base, Core))
 
@@ -431,4 +432,11 @@ end
     @test N[-3, -4] == 1
     V = no_offset_view(N)
     @test collect(V) == A
+
+    # bidirectional
+    B = BidirectionalVector([1, 2, 3])
+    pushfirst!(B, 0)
+    OB = OffsetArrays.no_offset_view(B)
+    @test axes(OB, 1) == 1:4
+    @test collect(OB) == 0:3
 end


### PR DESCRIPTION
Add a function to return a view with 1-based indexing. Cf [discussion](https://discourse.julialang.org/t/lift-and-wrap-array-with-custom-indexes/19436/11).

I thought this package would be the natural place for this, since it is implemented using `OffsetArray`, but feel free to reject if you don't think it fits into the scope of this package.

Suggestions about the name are welcome.