### PR TITLE
Avoid a level of indirection when nesting OffsetArrays.

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -59,9 +59,11 @@ OffsetArray(A::AbstractArray{T,N}, inds::Vararg{AbstractUnitRange,N}) where {T,N
     OffsetArray(A, inds)
 
 # avoid a level of indirection when nesting OffsetArrays
-function OffsetArray(A::OffsetArray, inds::Vararg{AbstractUnitRange})
+function OffsetArray(A::OffsetArray, inds::NTuple{N,AbstractUnitRange}) where {N}
     OffsetArray(parent(A), inds)
 end
+OffsetArray(A::OffsetArray{T,0}, inds::Tuple{}) where {T} = OffsetArray{T,0,typeof(A)}(parent(A), ())
+OffsetArray(A::OffsetArray{T,N}, inds::Tuple{}) where {T,N} = error("this should never be called")
 
 Base.IndexStyle(::Type{OA}) where {OA<:OffsetArray} = IndexStyle(parenttype(OA))
 parenttype(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -58,6 +58,11 @@ end
 OffsetArray(A::AbstractArray{T,N}, inds::Vararg{AbstractUnitRange,N}) where {T,N} =
     OffsetArray(A, inds)
 
+# avoid a level of indirection when nesting OffsetArrays
+function OffsetArray(A::OffsetArray, inds::Vararg{AbstractUnitRange})
+    OffsetArray(parent(A), inds)
+end
+
 Base.IndexStyle(::Type{OA}) where {OA<:OffsetArray} = IndexStyle(parenttype(OA))
 parenttype(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA
 parenttype(A::OffsetArray) = parenttype(typeof(A))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -401,3 +401,14 @@ end
     @test OffsetVector(v, -2:2) == OffsetArray(v, -2:2)
     @test typeof(OffsetVector{Float64}(undef, -2:2)) == typeof(OffsetArray{Float64}(undef, -2:2))
 end
+
+@testset "no nesting" begin
+    A = randn(2, 3)
+    x = A[2, 2]
+    O1 = OffsetArray(A, -1:0, -1:1)
+    O2 = OffsetArray(O1, 0:1, 0:2)
+    @test parent(O1) ≡ parent(O2)
+    @test eltype(O1) ≡ eltype(O2)
+    O2[1, 1] = x + 1            # just a sanity check
+    @test A[2, 2] == x + 1
+end


### PR DESCRIPTION
Fixes #44.