### PR TITLE
Redesign around IdOffsetRange

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "0.11.4"
+version = "1.0.0"
 
 [compat]
 julia = "0.7, 1"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,54 @@
 # OffsetArrays.jl
 
+[![Build Status](https://travis-ci.org/JuliaArrays/OffsetArrays.jl.svg?branch=master)](https://travis-ci.org/JuliaArrays/OffsetArrays.jl)
+[![codecov.io](http://codecov.io/github/JuliaArrays/OffsetArrays.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaArrays/OffsetArrays.jl?branch=master)
+[![PkgEval][pkgeval-img]][pkgeval-url]
+
 
 OffsetArrays provides Julia users with arrays that have arbitrary
 indices, similar to those found in some other programming languages
 like Fortran.
+
+## Usage
+
+You can construct such arrays as follows:
+
+```julia
+OA = OffsetArray(A, axis1, axis2, ...)
+```
+
+where you want `OA` to have axes `(axis1, axis2, ...)` and be indexed by values that
+fall within these axis ranges. Example:
+
+```julia
+using OffsetArrays
+A = reshape(1:15, 3, 5)
+println("here is A:")
+display(A)
+OA = OffsetArray(A, -1:1, 0:4)    # OA will have axes (-1:1, 0:4)
+println("here is OA:")
+display(OA)
+@show OA[-1,0] OA[1,4]
+```
+
+which prints out
+
+```
+here is A:
+3×5 reshape(::UnitRange{Int64}, 3, 5) with eltype Int64:
+ 1  4  7  10  13
+ 2  5  8  11  14
+ 3  6  9  12  15
+here is OA:
+OffsetArray(reshape(::UnitRange{Int64}, 3, 5), -1:1, 0:4) with eltype Int64 with indices -1:1×0:4:
+ 1  4  7  10  13
+ 2  5  8  11  14
+ 3  6  9  12  15
+OA[-1, 0] = 1
+OA[1, 4] = 15
+```
+
+OffsetArrays works for arbitrary dimensionality:
 
 ```julia
 julia> using OffsetArrays
@@ -21,7 +66,8 @@ julia> y[-1,-7,-128,-5,-1,-3,-2,-1] += 5
 ```
 
 ## Example: Relativistic Notation
-Suppose we have a position vector `r = [:x, :y, :z]` which is naturally one-based, ie. `r[1] == :x`, `r[2] == :y`,  `r[3] == :z` and we also want to construct a relativistic position vector which includes time as the 0th component. This can be done with OffsetArrays like 
+Suppose we have a position vector `r = [:x, :y, :z]` which is naturally one-based, ie. `r[1] == :x`, `r[2] == :y`,  `r[3] == :z` and we also want to construct a relativistic position vector which includes time as the 0th component. This can be done with OffsetArrays like
+
 ```julia
 julia> using OffsetArrays
 
@@ -49,7 +95,7 @@ Suppose one wants to represent the Laurent polynomial
 ```
 6/x + 5 - 2*x + 3*x^2 + x^3
 ```
-in julia. The coefficients of this polynomial are a naturally `-1` based list, since the `n`th element of the list 
+in julia. The coefficients of this polynomial are a naturally `-1` based list, since the `n`th element of the list
 (counting from `-1`) `6, 5, -2, 3, 1` is the coefficient corresponding to the `n`th power of `x`. This Laurent polynomial can be evaluated at say `x = 2` as follows.
 ```julia
 julia> using OffsetArrays
@@ -72,4 +118,8 @@ Notice our use of the `eachindex` function which does not assume that the given 
 
 ## Notes on supporting OffsetArrays
 
-Julia supports generic programming with arrays that doesn't require you to assume that indices start with 1, see the [documentation](http://docs.julialang.org/en/latest/devdocs/offset-arrays/).
+There are several "tricks" that make it easier to support arrays with general indexes, see the [documentation](http://docs.julialang.org/en/latest/devdocs/offset-arrays/).
+
+
+[pkgeval-img]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/O/OffsetArrays.svg
+[pkgeval-url]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -378,5 +378,8 @@ Base.searchsortedfirst(v::OffsetArray, x, lo::T, hi::T, o::Base.Ordering) where 
 Base.searchsortedlast(v::OffsetArray, x, lo::T, hi::T, o::Base.Ordering) where T<:Integer =
     _safe_searchsortedlast(v, x, lo, hi, o)
 
+if VERSION < v"1.1.0-DEV.783"
+    Base.copyfirst!(dest::OffsetArray, src::OffsetArray) = (maximum!(parent(dest), parent(src)); return dest)
+end
 
 end # module

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -84,11 +84,24 @@ OffsetArray{T}(init::ArrayInitializer, inds::Vararg{AbstractUnitRange,N}) where 
 OffsetVector(A::AbstractVector, offset) = OffsetArray(A, offset)
 OffsetVector{T}(init::ArrayInitializer, inds::AbstractUnitRange) where {T} = OffsetArray{T}(init, inds)
 
-# # The next two are necessary for ambiguity resolution. Really, the
-# # second method should not be necessary.
-# OffsetArray(A::AbstractArray{T,0}, inds::Tuple{}) where {T} = OffsetArray{T,0,typeof(A)}(A, ())
-# OffsetArray(A::AbstractArray{T,N}, inds::Tuple{}) where {T,N} = error("this should never be called")
+"""
+    OffsetArray(A, indices...)
 
+Return an `AbstractArray` that shares element type and size with the first argument, but
+used the given `indices`, which are checked for compatible size.
+
+# Example
+
+```jldoctest
+julia> A = OffsetArray(reshape(1:6, 2, 3), 0:1, -1:1)
+OffsetArray(reshape(::UnitRange{Int64}, 2, 3), 0:1, -1:1) with eltype Int64 with indices 0:1×-1:1:
+ 1  3  5
+ 2  4  6
+
+julia> A[0, 1]
+5
+```
+"""
 function OffsetArray(A::AbstractArray{T,N}, inds::NTuple{N,AbstractUnitRange}) where {T,N}
     axparent = axes(A)
     lA = map(length, axparent)


### PR DESCRIPTION
This is breaking and might be a good excuse to go to 1.0. Fixes the observation in https://github.com/JuliaArrays/OffsetArrays.jl/pull/65#issuecomment-457181268 even for other array types that offset their axes (see [this test](https://github.com/JuliaArrays/OffsetArrays.jl/blob/f383ae0d0b139a44e86cc1111470390ddfb83f2e/test/runtests.jl#L60-L65)).

The motivation is discussed in more detail in https://discourse.julialang.org/t/why-is-there-a-performance-hit-on-broadcasting-with-offsetarrays/32194. There's something pretty satisfying, though, about offsetting the axes by a "lazy" mechanism
https://github.com/JuliaArrays/OffsetArrays.jl/blob/f383ae0d0b139a44e86cc1111470390ddfb83f2e/src/OffsetArrays.jl#L18-L21
https://github.com/JuliaArrays/OffsetArrays.jl/blob/f383ae0d0b139a44e86cc1111470390ddfb83f2e/src/OffsetArrays.jl#L41-L42
because it makes it more possible to preserve any custom behavior of the parent array's axes.

CC @mbauman