### PR TITLE
Delete undefined type parameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.0.1"
+version = "1.0.2"
 
 [compat]
 julia = "0.7, 1"

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -129,12 +129,12 @@ offset_coerce(::Type{I}, r::AbstractUnitRange) where I<:AbstractUnitRange{T} whe
 @inline Base.unsafe_indices(r::IdOffsetRange) = (r,)
 @inline Base.length(r::IdOffsetRange) = length(r.parent)
 
-function Base.iterate(r::IdOffsetRange)
+@inline function Base.iterate(r::IdOffsetRange)
     ret = iterate(r.parent)
     ret === nothing && return nothing
     return (ret[1] + r.offset, ret[2])
 end
-function Base.iterate(r::IdOffsetRange, i) where T
+@inline function Base.iterate(r::IdOffsetRange, i)
     ret = iterate(r.parent, i)
     ret === nothing && return nothing
     return (ret[1] + r.offset, ret[2])


### PR DESCRIPTION
That undefined `T` caused a major performance regression. Fixes #96.