### PR TITLE
Corrects offset1 computing of SubArray for IdOffsetRange

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -128,12 +128,9 @@ offset_coerce(::Type{I}, r::AbstractUnitRange) where I<:AbstractUnitRange{T} whe
 @inline Base.axes1(r::IdOffsetRange) = IdOffsetRange(Base.axes1(r.parent), r.offset)
 @inline Base.unsafe_indices(r::IdOffsetRange) = (r,)
 @inline Base.length(r::IdOffsetRange) = length(r.parent)
-@inline function Base.compute_linindex(f, s, IP::Tuple, I::Tuple{IdOffsetRange, Vararg{Any}})
-    # issue 100
-    # IdOffsetRange doesn't contributes to offsets before the construction of SubArray
-    Δi =  1 - first(IP[1])
-    Base.compute_linindex(f + Δi*s, s*Base.unsafe_length(IP[1]), Base.tail(IP), Base.tail(I))
-end
+# issue 100: IdOffsetRange as another index-preserving case shouldn't comtribute offsets
+@inline Base.compute_offset1(parent, stride1::Integer, dims::Tuple{Int}, inds::Tuple{IdOffsetRange}, I::Tuple) =
+    Base.compute_linindex(parent, I) - stride1*first(axes(parent, dims[1]))
 
 @inline function Base.iterate(r::IdOffsetRange)
     ret = iterate(r.parent)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -128,6 +128,12 @@ offset_coerce(::Type{I}, r::AbstractUnitRange) where I<:AbstractUnitRange{T} whe
 @inline Base.axes1(r::IdOffsetRange) = IdOffsetRange(Base.axes1(r.parent), r.offset)
 @inline Base.unsafe_indices(r::IdOffsetRange) = (r,)
 @inline Base.length(r::IdOffsetRange) = length(r.parent)
+@inline function Base.compute_linindex(f, s, IP::Tuple, I::Tuple{IdOffsetRange, Vararg{Any}})
+    # issue 100
+    # IdOffsetRange doesn't contributes to offsets before the construction of SubArray
+    Δi =  1 - first(IP[1])
+    Base.compute_linindex(f + Δi*s, s*Base.unsafe_length(IP[1]), Base.tail(IP), Base.tail(I))
+end
 
 @inline function Base.iterate(r::IdOffsetRange)
     ret = iterate(r.parent)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,6 +278,37 @@ end
     @test S[1,4] == S[4] == 4
     @test_throws BoundsError S[1,1]
     @test axes(S) == IdentityUnitRange.((0:1, 3:4))
+    S = view(A, axes(A)...)
+    @test S == A
+    @test S[0,3] == S[1] == 1
+    @test S[1,3] == S[2] == 2
+    @test S[0,4] == S[3] == 3
+    @test S[1,4] == S[4] == 4
+    @test_throws BoundsError S[1,1]
+    @test axes(S) == OffsetArrays.IdOffsetRange.((0:1, 3:4))
+    # issue 100
+    S = view(A, axes(A, 1), 3)
+    @test S == A[:, 3]
+    @test S[0] == 1
+    @test S[1] == 2
+    @test_throws BoundsError S[length(S)]
+    @test axes(S) == (OffsetArrays.IdOffsetRange(0:1), )
+    # issue 100
+    S = view(A, 1, axes(A, 2))
+    @test S == A[1, :]
+    @test S[3] == 2
+    @test S[4] == 4
+    @test_throws BoundsError S[1]
+    @test axes(S) == (OffsetArrays.IdOffsetRange(3:4), )
+
+    A0 = collect(reshape(1:24, 2, 3, 4))
+    A = OffsetArray(A0, (-1,2,1))
+    S = view(A, axes(A, 1), 3:4, axes(A, 3))
+    @test S == A[:, 3:4, :]
+    @test S[0, 1, 2] == A[0, 3, 2]
+    @test S[0, 2, 2] == A[0, 4, 2]
+    @test S[1, 1, 2] == A[1, 3, 2]
+    @test axes(S) == (OffsetArrays.IdOffsetRange(0:1), Base.OneTo(2), OffsetArrays.IdOffsetRange(2:5))
 end
 
 @testset "iteration" begin


### PR DESCRIPTION
I believe this patch somehow fixes issue #100 but it needs careful review since I might misunderstand the design of SubArray and IdOffsetRange...

~issue #100 seems only happens when it's a linear index~


P.S. Tests labeled with `issue #100` were broken without this patch

cc: @mcabbott
