### PR TITLE
Reuse `similar` for `undef` initialization

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -126,15 +126,15 @@ function Base.similar(::Type{T}, shape::Tuple{OffsetAxis,Vararg{OffsetAxis}}) wh
 end
 
 Base.fill(v, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-    fill!(OffsetArray(Array{typeof(v), N}(undef, map(indexlength, inds)), map(indexoffset, inds)), v)
+    fill!(similar(Array{typeof(v)}, inds), v)
 Base.zeros(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
-    fill!(OffsetArray(Array{T, N}(undef, map(indexlength, inds)), map(indexoffset, inds)), zero(T))
+    fill!(similar(Array{T}, inds), zero(T))
 Base.ones(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
-    fill!(OffsetArray(Array{T, N}(undef, map(indexlength, inds)), map(indexoffset, inds)), one(T))
+    fill!(similar(Array{T}, inds), one(T))
 Base.trues(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-    fill!(OffsetArray(BitArray{N}(undef, map(indexlength, inds)), map(indexoffset, inds)), true)
+    fill!(similar(BitArray, inds), true)
 Base.falses(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-    fill!(OffsetArray(BitArray{N}(undef, map(indexlength, inds)), map(indexoffset, inds)), false)
+    fill!(similar(BitArray, inds), false)
 
 ## Indexing
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -207,12 +207,6 @@ function Base.show(io::IO, r::OffsetRange)
 end
 Base.show(io::IO, ::MIME"text/plain", r::OffsetRange) = show(io, r)
 
-### Convenience functions ###
-
-Base.fill(x, inds::Tuple{UnitRange,Vararg{UnitRange}}) =
-    fill!(OffsetArray{typeof(x)}(undef, inds), x)
-@inline Base.fill(x, ind1::UnitRange, inds::UnitRange...) = fill(x, (ind1, inds...))
-
 
 ### Some mutating functions defined only for OffsetVector ###
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,7 @@ end
     @test axes(a) == ()
     @test ndims(a) == 0
     @test a[] == 3
+    @test a == OffsetArray(a, ())
 end
 
 @testset "OffsetVector constructors" begin
@@ -393,6 +394,9 @@ end
     @test similar(Array{Int}, (0:0, 0:0)) isa OffsetArray{Int, 2}
     @test similar(Array{Int}, (1, 1)) isa Matrix{Int}
     @test similar(Array{Int}, (Base.OneTo(1), Base.OneTo(1))) isa Matrix{Int}
+    B = similar(Array{Int}, (0:0, 3))
+    @test isa(B, OffsetArray{Int, 2})
+    @test axes(B) == (0:0, 1:3)
 end
 
 @testset "reshape" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -612,6 +612,14 @@ end
     B = fill(5, 1:3, -1:1)
     @test axes(B) == (1:3,-1:1)
     @test all(B.==5)
+
+    B = fill(5, (1:3, -1:1))
+    @test axes(B) == (1:3,-1:1)
+    @test all(B.==5)
+
+    B = fill(5, 3, -1:1)
+    @test axes(B) == (1:3,-1:1)
+    @test all(B.==5)
 end
 
 @testset "broadcasting" begin


### PR DESCRIPTION
I didn't check carefully, but I expect this is equivalent, and it looks clearer to me.