### PR TITLE
fix code instability of axes

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -92,8 +92,8 @@ Base.eachindex(::IndexLinear, A::OffsetVector)   = axes(A, 1)
 @inline Base.size(A::OffsetArray, d) = size(parent(A), d)
 
 @inline Base.axes(A::OffsetArray) = map(IdOffsetRange, axes(parent(A)), A.offsets)
-@inline Base.axes(A::OffsetArray, d) = d <= ndims(A) ? IdOffsetRange(axes(parent(A), d), A.offsets[d]) : Base.OneTo(1)
-@inline Base.axes1(A::OffsetArray{T,0}) where {T} = Base.OneTo(1)  # we only need to specialize this one
+@inline Base.axes(A::OffsetArray, d) = d <= ndims(A) ? IdOffsetRange(axes(parent(A), d), A.offsets[d]) : IdOffsetRange(Base.OneTo(1))
+@inline Base.axes1(A::OffsetArray{T,0}) where {T} = IdOffsetRange(Base.OneTo(1))  # we only need to specialize this one
 
 const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, IdentityUnitRange, IdOffsetRange, Colon}
 Base.similar(A::OffsetArray, ::Type{T}, dims::Dims) where T =

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -92,8 +92,8 @@ Base.eachindex(::IndexLinear, A::OffsetVector)   = axes(A, 1)
 @inline Base.size(A::OffsetArray, d) = size(parent(A), d)
 
 @inline Base.axes(A::OffsetArray) = map(IdOffsetRange, axes(parent(A)), A.offsets)
-@inline Base.axes(A::OffsetArray, d) = d <= ndims(A) ? IdOffsetRange(axes(parent(A), d), A.offsets[d]) : IdOffsetRange(Base.OneTo(1))
-@inline Base.axes1(A::OffsetArray{T,0}) where {T} = IdOffsetRange(Base.OneTo(1))  # we only need to specialize this one
+@inline Base.axes(A::OffsetArray, d) = d <= ndims(A) ? IdOffsetRange(axes(parent(A), d), A.offsets[d]) : IdOffsetRange(axes(parent(A), d))
+@inline Base.axes1(A::OffsetArray{T,0}) where {T} = IdOffsetRange(axes(parent(A), 1))  # we only need to specialize this one
 
 const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, IdentityUnitRange, IdOffsetRange, Colon}
 Base.similar(A::OffsetArray, ::Type{T}, dims::Dims) where T =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,7 +154,9 @@ end
     A0 = [1 3; 2 4]
     A = OffsetArray(A0, (-1,2))                   # IndexLinear
     S = OffsetArray(view(A0, 1:2, 1:2), (-1,2))   # IndexCartesian
+    @test axes(A) === axes(S)
     @test axes(A) == axes(S) == (0:1, 3:4)
+    @test axes(A, 1) === OffsetArrays.IdOffsetRange(Base.OneTo(2), -1)
     @test size(A) == size(A0)
     @test size(A, 1) == size(A0, 1)
     @test length(A) == length(A0)


### PR DESCRIPTION
This fixes #116

Switching from `Base.OneTo` to `IdOffsetRange` might introduces some incompatibility issue for downstream packages since IIUC `IdOffsetRange` is still at experimental status, so I'd prefer to not merge this PR until we revisit and polish the design of `IdOffsetRange`.

P.S., perhaps surprisingly, the type instability in #116 doesn't slow down the codes:

```julia
julia> @btime axes(a)
  17.472 ns (1 allocation: 32 bytes)
(-1:1,)

julia> @btime axes(a, 1)
  18.725 ns (1 allocation: 32 bytes)
-1:1

julia> @btime axes(a, 2)
  17.037 ns (0 allocations: 0 bytes)
Base.OneTo(1)
```

cc: @jishnub