### PR TITLE
setindex! returns the array instead of the value

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -157,18 +157,18 @@ end
     @boundscheck checkbounds(A, I...)
     J = @inbounds map(parentindex, axes(A), I)
     @inbounds parent(A)[J...] = val
-    val
+    A
 end
 
 @propagate_inbounds function Base.setindex!(A::OffsetVector, val, i::Int)
     @boundscheck checkbounds(A, i)
     @inbounds parent(A)[parentindex(Base.axes1(A), i)] = val
-    val
+    A
 end
 @propagate_inbounds function Base.setindex!(A::OffsetArray, val, i::Int)
     @boundscheck checkbounds(A, i)
     @inbounds parent(A)[i] = val
-    val
+    A
 end
 
 # For fast broadcasting: ref https://discourse.julialang.org/t/why-is-there-a-performance-hit-on-broadcasting-with-offsetarrays/32194

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,6 +198,18 @@ end
     y[-1,-7,-128,-5,-1,-3,-2,-1] = 14
     y[-1,-7,-128,-5,-1,-3,-2,-1] += 5
     @test y[-1,-7,-128,-5,-1,-3,-2,-1] == 19
+
+    @testset "setindex!" begin
+        A = OffsetArray(ones(2,2), 1:2, 1:2)
+        @test setindex!(A, 2, 1, 1) === A
+        @test A[1,1] == 2
+        @test setindex!(A, 2, 1) === A
+        @test A[1] == 2
+
+        v = OffsetArray(ones(3), 4:6)
+        @test setindex!(A, 2, 4) === A
+        @test A[4] == 2
+    end
 end
 
 @testset "Vector indexing" begin


### PR DESCRIPTION
Fixes #123 

```julia
julia> setindex!(OffsetArray(ones(3),1:3),2,1)
3-element OffsetArray(::Array{Float64,1}, 1:3) with eltype Float64 with indices 1:3:
 2.0
 1.0
 1.0
```