### PR TITLE
similar does not accept colons as indices

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -95,17 +95,17 @@ Base.eachindex(::IndexLinear, A::OffsetVector)   = axes(A, 1)
 @inline Base.axes(A::OffsetArray, d) = d <= ndims(A) ? IdOffsetRange(axes(parent(A), d), A.offsets[d]) : IdOffsetRange(axes(parent(A), d))
 @inline Base.axes1(A::OffsetArray{T,0}) where {T} = IdOffsetRange(axes(parent(A), 1))  # we only need to specialize this one
 
-const OffsetAxisHasLength = Union{Integer, UnitRange, Base.OneTo, IdentityUnitRange, IdOffsetRange}
+const OffsetAxisKnownLength = Union{Integer, UnitRange, Base.OneTo, IdentityUnitRange, IdOffsetRange}
 
 Base.similar(A::OffsetArray, ::Type{T}, dims::Dims) where T =
     similar(parent(A), T, dims)
-function Base.similar(A::AbstractArray, ::Type{T}, inds::Tuple{OffsetAxisHasLength,Vararg{OffsetAxisHasLength}}) where T
+function Base.similar(A::AbstractArray, ::Type{T}, inds::Tuple{OffsetAxisKnownLength,Vararg{OffsetAxisKnownLength}}) where T
     B = similar(A, T, map(indexlength, inds))
     return OffsetArray(B, map(offset, axes(B), inds))
 end
 
 # reshape accepts a single colon
-const OffsetAxis = Union{OffsetAxisHasLength, Colon}
+const OffsetAxis = Union{OffsetAxisKnownLength, Colon}
 Base.reshape(A::AbstractArray, inds::OffsetAxis...) = reshape(A, inds)
 function Base.reshape(A::AbstractArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}})
     AR = reshape(A, map(indexlength, inds))

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -95,14 +95,17 @@ Base.eachindex(::IndexLinear, A::OffsetVector)   = axes(A, 1)
 @inline Base.axes(A::OffsetArray, d) = d <= ndims(A) ? IdOffsetRange(axes(parent(A), d), A.offsets[d]) : IdOffsetRange(axes(parent(A), d))
 @inline Base.axes1(A::OffsetArray{T,0}) where {T} = IdOffsetRange(axes(parent(A), 1))  # we only need to specialize this one
 
-const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, IdentityUnitRange, IdOffsetRange, Colon}
+const OffsetAxisHasLength = Union{Integer, UnitRange, Base.OneTo, IdentityUnitRange, IdOffsetRange}
+
 Base.similar(A::OffsetArray, ::Type{T}, dims::Dims) where T =
     similar(parent(A), T, dims)
-function Base.similar(A::AbstractArray, ::Type{T}, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}}) where T
+function Base.similar(A::AbstractArray, ::Type{T}, inds::Tuple{OffsetAxisHasLength,Vararg{OffsetAxisHasLength}}) where T
     B = similar(A, T, map(indexlength, inds))
     return OffsetArray(B, map(offset, axes(B), inds))
 end
 
+# reshape accepts a single colon
+const OffsetAxis = Union{OffsetAxisHasLength, Colon}
 Base.reshape(A::AbstractArray, inds::OffsetAxis...) = reshape(A, inds)
 function Base.reshape(A::AbstractArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}})
     AR = reshape(A, map(indexlength, inds))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,6 +416,12 @@ end
     B = similar(Array{Int}, (0:0, 3))
     @test isa(B, OffsetArray{Int, 2})
     @test axes(B) == (0:0, 1:3)
+
+    @test_throws MethodError similar(A, (:,))
+    @test_throws MethodError similar(A, (: ,:))
+    @test_throws MethodError similar(A, (: ,2))
+    @test_throws MethodError similar(A, Float64, (: ,:))
+    @test_throws MethodError similar(A, Float64, (: ,2))
 end
 
 @testset "reshape" begin


### PR DESCRIPTION
This attempts to get around #122 by explicitly preventing colons being passed to `similar`. This means that the `StackOverflowError` now becomes a `MethodError`

```julia
julia> oa = OffsetArray(rand(3,3), 0:2, 0:2)
3×3 OffsetArray(::Array{Float64,2}, 0:2, 0:2) with eltype Float64 with indices 0:2×0:2:
 0.339644  0.584673  0.474432
 0.689602  0.65758   0.673912
 0.920069  0.360913  0.917047

julia> similar(oa, Float64, (:,:))
ERROR: MethodError: no method matching similar(::OffsetArray{Float64,2,Array{Float64,2}}, ::Type{Float64}, ::Tuple{Colon,Colon})
```