### PR TITLE
Inherit matrix printing style from the parent array

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,8 @@ julia = "0.7, 1"
 [extras]
 CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CatIndices", "DelimitedFiles", "Test"]
+test = ["CatIndices", "DelimitedFiles", "Test", "LinearAlgebra"]

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -240,9 +240,13 @@ printindices(io::IO, ind1) = print(io, _unslice(ind1))
 _unslice(x) = x
 _unslice(x::IdentityUnitRange) = x.indices
 
-function Base.replace_in_print_matrix(A::OffsetArray, i::Integer, j::Integer, s::AbstractString)
+function Base.replace_in_print_matrix(A::OffsetArray{<:Any,2}, i::Integer, j::Integer, s::AbstractString)
     J = map(parentindex, axes(A), (i,j))
     Base.replace_in_print_matrix(parent(A), J..., s)
+end
+function Base.replace_in_print_matrix(A::OffsetArray{<:Any,1}, i::Integer, j::Integer, s::AbstractString)
+    ip = parentindex(axes(A,1), i)
+    Base.replace_in_print_matrix(parent(A), ip, j, s)
 end
 
 """

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -240,6 +240,11 @@ printindices(io::IO, ind1) = print(io, _unslice(ind1))
 _unslice(x) = x
 _unslice(x::IdentityUnitRange) = x.indices
 
+function Base.replace_in_print_matrix(A::OffsetArray, i::Integer, j::Integer, s::AbstractString)
+    J = map(parentindex, axes(A), (i,j))
+    Base.replace_in_print_matrix(parent(A), J..., s)
+end
+
 """
     no_offset_view(A)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 using DelimitedFiles
 using OffsetArrays: IdentityUnitRange, no_offset_view
 using CatIndices: BidirectionalVector
+using LinearAlgebra
 
 @test isempty(detect_ambiguities(OffsetArrays, Base, Core))
 
@@ -380,6 +381,13 @@ end
 
     show(io, OffsetArray(3:5, 0:2))
     @test String(take!(io)) == "3:5 with indices 0:2"
+
+    d = Diagonal([1,2,3])
+    Base.print_array(io, d)
+    s1 = String(take!(io))
+    Base.print_array(io, OffsetArray(d, -1:1, 3:5))
+    s2 = String(take!(io))
+    @test s1 == s2
 end
 
 @testset "readdlm/writedlm" begin


### PR DESCRIPTION
After this PR:

```julia
julia> OffsetArray(Diagonal([1,2,3]),1:3,2:4)
3×3 OffsetArray(::Diagonal{Int64,Array{Int64,1}}, 1:3, 2:4) with eltype Int64 with indices 1:3×2:4:
 1  ⋅  ⋅
 ⋅  2  ⋅
 ⋅  ⋅  3
```

as opposed to the behavior on master

```julia
julia> OffsetArray(Diagonal([1,2,3]),1:3,2:4)
3×3 OffsetArray(::Diagonal{Int64,Array{Int64,1}}, 1:3, 2:4) with eltype Int64 with indices 1:3×2:4:
 1  0  0
 0  2  0
 0  0  3
```

This makes it easier to identify sparse arrays.