### PR TITLE
Perform bounds checking in indexing instead of deferring to the parent array

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -145,29 +145,32 @@ Base.falses(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
 # and one obtains the result below.
 parentindex(r::IdOffsetRange, i) = i - r.offset
 
-@propagate_inbounds function Base.getindex(A::OffsetArray{T,N}, I::Vararg{Int,N}) where {T,N}
+@inline function Base.getindex(A::OffsetArray{T,N}, I::Vararg{Int,N}) where {T,N}
+    @boundscheck checkbounds(A, I...)
     J = map(parentindex, axes(A), I)
-    return parent(A)[J...]
+    @inbounds parent(A)[J...]
 end
 
-@propagate_inbounds Base.getindex(A::OffsetVector, i::Int) = parent(A)[parentindex(Base.axes1(A), i)]
+@inline function Base.getindex(A::OffsetVector, i::Int)
+    @boundscheck checkbounds(A, i)
+    @inbounds parent(A)[parentindex(Base.axes1(A), i)]
+end
 @propagate_inbounds Base.getindex(A::OffsetArray, i::Int)  = parent(A)[i]
 
-@propagate_inbounds function Base.setindex!(A::OffsetArray{T,N}, val, I::Vararg{Int,N}) where {T,N}
+@inline function Base.setindex!(A::OffsetArray{T,N}, val, I::Vararg{Int,N}) where {T,N}
     @boundscheck checkbounds(A, I...)
     J = @inbounds map(parentindex, axes(A), I)
     @inbounds parent(A)[J...] = val
     A
 end
 
-@propagate_inbounds function Base.setindex!(A::OffsetVector, val, i::Int)
+@inline function Base.setindex!(A::OffsetVector, val, i::Int)
     @boundscheck checkbounds(A, i)
     @inbounds parent(A)[parentindex(Base.axes1(A), i)] = val
     A
 end
 @propagate_inbounds function Base.setindex!(A::OffsetArray, val, i::Int)
-    @boundscheck checkbounds(A, i)
-    @inbounds parent(A)[i] = val
+    parent(A)[i] = val
     A
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,10 +185,10 @@ end
     @test @inbounds(A[1,3]) == @inbounds(A[1,3,1]) == @inbounds(A[2]) == @inbounds(S[1,3]) == @inbounds(S[1,3,1]) == @inbounds(S[2]) == 2
     @test @inbounds(A[0,4]) == @inbounds(A[0,4,1]) == @inbounds(A[3]) == @inbounds(S[0,4]) == @inbounds(S[0,4,1]) == @inbounds(S[3]) == 3
     @test @inbounds(A[1,4]) == @inbounds(A[1,4,1]) == @inbounds(A[4]) == @inbounds(S[1,4]) == @inbounds(S[1,4,1]) == @inbounds(S[4]) == 4
-    @test_throws BoundsError A[1,1]
-    @test_throws BoundsError S[1,1]
-    @test_throws BoundsError A[0,3,2]
-    @test_throws BoundsError A[0,3,0]
+    @test_throws BoundsError(A, (1,1)) A[1,1]
+    @test_throws BoundsError(S, (1,1)) S[1,1]
+    @test_throws BoundsError(A, (0,3,2)) A[0,3,2]
+    @test_throws BoundsError(A, (0,3,0)) A[0,3,0]
     Ac = copy(A)
     Ac[0,3] = 10
     @test Ac[0,3] == 10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,9 +186,13 @@ end
     @test @inbounds(A[0,4]) == @inbounds(A[0,4,1]) == @inbounds(A[3]) == @inbounds(S[0,4]) == @inbounds(S[0,4,1]) == @inbounds(S[3]) == 3
     @test @inbounds(A[1,4]) == @inbounds(A[1,4,1]) == @inbounds(A[4]) == @inbounds(S[1,4]) == @inbounds(S[1,4,1]) == @inbounds(S[4]) == 4
     @test_throws BoundsError(A, (1,1)) A[1,1]
+    @test_throws BoundsError(A, (1,1)) A[1,1] = 4
     @test_throws BoundsError(S, (1,1)) S[1,1]
+    @test_throws BoundsError(S, (1,1)) S[1,1] = 4
     @test_throws BoundsError(A, (0,3,2)) A[0,3,2]
+    @test_throws BoundsError(A, (0,3,2)) A[0,3,2] = 4
     @test_throws BoundsError(A, (0,3,0)) A[0,3,0]
+    @test_throws BoundsError(A, (0,3,0)) A[0,3,0] = 4
     Ac = copy(A)
     Ac[0,3] = 10
     @test Ac[0,3] == 10


### PR DESCRIPTION
This PR improves the error message in case an out-of-bounds indexing operation has been performed. At present, the bounds checking is left to the parent, which leads to the error message referring to the result of `parentindex` rather than those used in the actual indexing operation.

Here's the intended behavior:

Presently on master:
```julia
julia> oa = zeros(-1:1, 3:3);

julia> oa[-2,3]
ERROR: BoundsError: attempt to access 3×1 Array{Float64,2} at index [0, 1]
```

After this PR:
```julia
julia> oa = zeros(-1:1, 3:3);

julia> oa[-2,3]
ERROR: BoundsError: attempt to access 3×1 OffsetArray(::Array{Float64,2}, -1:1, 3:3) with eltype Float64 with indices -1:1×3:3 at index [-2, 3]
```
