### PR TITLE
Fix #133: compute_offset1 for an IdOffsetRange axis

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -131,7 +131,7 @@ offset_coerce(::Type{I}, r::AbstractUnitRange) where I<:AbstractUnitRange{T} whe
 @inline Base.length(r::IdOffsetRange) = length(r.parent)
 # issue 100: IdOffsetRange as another index-preserving case shouldn't comtribute offsets
 @inline Base.compute_offset1(parent, stride1::Integer, dims::Tuple{Int}, inds::Tuple{IdOffsetRange}, I::Tuple) =
-    Base.compute_linindex(parent, I) - stride1*first(axes(parent, dims[1]))
+    Base.compute_linindex(parent, I) - stride1*first(inds[1])
 Base.reduced_index(i::IdOffsetRange) = typeof(i)(first(i):first(i))
 # Workaround for #92 on Julia < 1.4
 Base.reduced_index(i::IdentityUnitRange{<:IdOffsetRange}) = typeof(i)(first(i):first(i))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -335,6 +335,35 @@ end
     @test_throws BoundsError S[1]
     @test axes(S) == (OffsetArrays.IdOffsetRange(3:4), )
 
+    # issue 133
+    r = OffsetArrays.IdOffsetRange(1:2, -1)
+    v1 = view(A, r, 3)
+    @test v1[0] == 1
+    @test v1[1] == 2
+    @test axes(v1, 1) == axes(r, 1)
+    v2 = view(A, UnitRange(r), 3)
+    for (indflat, indoffset) in enumerate(r)
+        @test v1[indoffset] == v2[indflat]
+    end
+
+    # issue 133
+    r = OffsetArrays.IdOffsetRange(1:2, 2)
+    v1 = view(A, 1, r)
+    @test v1[3] == 2
+    @test v1[4] == 4
+    @test axes(v1, 1) == axes(r, 1)
+    v2 = view(A, 1, UnitRange(r))
+    for (indflat, indoffset) in enumerate(r)
+        @test v1[indoffset] == v2[indflat]
+    end
+
+    # issue 133
+    a12 = zeros(3:8, 3:4)
+    r = OffsetArrays.IdOffsetRange(Base.OneTo(3), 5)
+    a12[r, 4] .= 3
+    @test all(a12[r, 4] .== 3)
+    @test all(a12[UnitRange(r), 4] .== 3)
+
     A0 = collect(reshape(1:24, 2, 3, 4))
     A = OffsetArray(A0, (-1,2,1))
     S = view(A, axes(A, 1), 3:4, axes(A, 3))


### PR DESCRIPTION
Now 

```julia
julia> a12 = zeros(3:8, 3:4);

julia> r = OffsetArrays.IdOffsetRange(Base.OneTo(3), 5)
6:8

julia> a12[r, 4] .= 3
3-element view(OffsetArray(::Array{Float64,2}, 3:8, 3:4), 6:8, 4) with eltype Float64 with indices 6:8:
 3.0
 3.0
 3.0

julia> a12
6×2 OffsetArray(::Array{Float64,2}, 3:8, 3:4) with eltype Float64 with indices 3:8×3:4:
 0.0  0.0
 0.0  0.0
 0.0  0.0
 0.0  3.0
 0.0  3.0
 0.0  3.0
```