### PR TITLE
WIP: Implement insert! and deleteat! for OffsetVectors

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -151,7 +151,7 @@ Base.falses(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
 #   Δi = i - first(r)
 #   i′ = first(r.parent) + Δi
 # and one obtains the result below.
-parentindex(r::IdOffsetRange, i) = i - r.offset
+parentindex(r::IdOffsetRange, i) = i .- r.offset
 
 @inline function Base.getindex(A::OffsetArray{T,N}, I::Vararg{Int,N}) where {T,N}
     @boundscheck checkbounds(A, I...)
@@ -225,6 +225,21 @@ Base.resize!(A::OffsetVector, nl::Integer) = (resize!(A.parent, nl); A)
 Base.push!(A::OffsetVector, x...) = (push!(A.parent, x...); A)
 Base.pop!(A::OffsetVector) = pop!(A.parent)
 Base.empty!(A::OffsetVector) = (empty!(A.parent); A)
+
+function Base.insert!(A::OffsetVector, i::Integer, item)
+    insert!(A.parent, parentindex(Base.axes1(A), i), item)
+    A
+end
+
+function Base.deleteat!(A::OffsetVector, i::Integer)
+    deleteat!(A.parent, parentindex(Base.axes1(A), i))
+    A
+end
+
+function Base.deleteat!(A::OffsetVector, r::UnitRange{<:Integer})
+    deleteat!(A.parent, parentindex(axes(A)[1], r))
+    A
+end
 
 ### Low-level utilities ###
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -810,6 +810,14 @@ end
     o = OffsetVector([1, 2, 3], -1)
     @test empty!(o) === o
     @test axes(o, 1) == 0:-1
+    # insert!
+    o = OffsetVector([4], 0:0)
+    @test insert!(o, 1, 2) == OffsetVector([4,2], 0:1)
+    @test insert!(o, 0, 1) == OffsetVector([1,4,2], 0:2)
+    # deleteat!
+    o = OffsetVector([10,11,12,13,14], 0:4)
+    @test deleteat!(o, 1:2) == OffsetVector([10,13,14], 0:2)
+    @test deleteat!(o, 0) == OffsetVector([13,14], 0:1)
 end
 
 @testset "searchsorted (#85)" begin


### PR DESCRIPTION
I consider this to be incomplete.  I have not, for instance, thought carefully about whether I am referring to the `axes` in the most appropriate way, but hey, all tests pass!  Also, ideally the offset indices will be used in the exception message when the index is out of range; right now, the indices of the parent array are instead provided, and this can be confusing.

