### PR TITLE
Implicitly specify axes using colons in the constructor

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -77,6 +77,17 @@ end
 OffsetArray(A::AbstractArray{T,N}, inds::Vararg{AbstractUnitRange,N}) where {T,N} =
     OffsetArray(A, inds)
 
+uncolonindices(A::AbstractArray{<:Any,N}, inds::NTuple{N,Any}) where {N} = uncolonindices(axes(A), inds)
+uncolonindices(ax::Tuple, inds::Tuple) = (first(inds), uncolonindices(tail(ax), tail(inds))...)
+uncolonindices(ax::Tuple, inds::Tuple{Colon, Vararg{Any}}) = (first(ax), uncolonindices(tail(ax), tail(inds))...)
+uncolonindices(::Tuple{}, ::Tuple{}) = ()
+
+function OffsetArray(A::AbstractArray{T,N}, inds::NTuple{N,Union{AbstractUnitRange, Colon}}) where {T,N}
+    OffsetArray(A, uncolonindices(A, inds))
+end
+OffsetArray(A::AbstractArray{T,N}, inds::Vararg{Union{AbstractUnitRange, Colon},N}) where {T,N} =
+    OffsetArray(A, uncolonindices(A, inds))
+
 # avoid a level of indirection when nesting OffsetArrays
 function OffsetArray(A::OffsetArray, offsets::NTuple{N,Int}) where {N}
     OffsetArray(parent(A), offsets .+ A.offsets)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,8 +107,7 @@ end
     @test OffsetVector(v, -2:2) == OffsetArray(v, -2:2)
     @test typeof(OffsetVector{Float64}(undef, -2:2)) == typeof(OffsetArray{Float64}(undef, -2:2))
 
-    @test OffsetVector(v, :) == OffsetArray(v, :)
-    @test OffsetVector(v, :) == OffsetArray(v, axes(v))
+    @test OffsetVector(v, :) == OffsetArray(v, (:,)) == OffsetArray(v, :) == OffsetArray(v, axes(v))
 end
 
 @testset "OffsetMatrix constructors" begin
@@ -117,8 +116,7 @@ end
     @test OffsetMatrix(v, -2:2, -1:1) == OffsetArray(v, -2:2, -1:1)
     @test typeof(OffsetMatrix{Float64}(undef, -2:2, -1:1)) == typeof(OffsetArray{Float64}(undef, -2:2, -1:1))
 
-    @test OffsetMatrix(v, :, :) == OffsetArray(v, :, :)
-    @test OffsetMatrix(v, :, :) == OffsetArray(v, axes(v))
+    @test OffsetMatrix(v, :, :) == OffsetArray(v, (:, :)) == OffsetArray(v, :, :) == OffsetArray(v, axes(v))
     @test OffsetMatrix(v, :, 2:4) == OffsetArray(v, axes(v,1), 2:4)
     @test OffsetMatrix(v, 3:7, :) == OffsetArray(v, 3:7, axes(v,2))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,9 @@ end
     @test OffsetVector(v, -2) == OffsetArray(v, -2)
     @test OffsetVector(v, -2:2) == OffsetArray(v, -2:2)
     @test typeof(OffsetVector{Float64}(undef, -2:2)) == typeof(OffsetArray{Float64}(undef, -2:2))
+
+    @test OffsetVector(v, :) == OffsetArray(v, :)
+    @test OffsetVector(v, :) == OffsetArray(v, axes(v))
 end
 
 @testset "OffsetMatrix constructors" begin
@@ -113,6 +116,11 @@ end
     @test OffsetMatrix(v, -2, -1) == OffsetArray(v, -2, -1)
     @test OffsetMatrix(v, -2:2, -1:1) == OffsetArray(v, -2:2, -1:1)
     @test typeof(OffsetMatrix{Float64}(undef, -2:2, -1:1)) == typeof(OffsetArray{Float64}(undef, -2:2, -1:1))
+
+    @test OffsetMatrix(v, :, :) == OffsetArray(v, :, :)
+    @test OffsetMatrix(v, :, :) == OffsetArray(v, axes(v))
+    @test OffsetMatrix(v, :, 2:4) == OffsetArray(v, axes(v,1), 2:4)
+    @test OffsetMatrix(v, 3:7, :) == OffsetArray(v, 3:7, axes(v,2))
 end
 
 @testset "undef, missing, and nothing constructors" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,6 +108,11 @@ end
     @test typeof(OffsetVector{Float64}(undef, -2:2)) == typeof(OffsetArray{Float64}(undef, -2:2))
 
     @test OffsetVector(v, :) == OffsetArray(v, (:,)) == OffsetArray(v, :) == OffsetArray(v, axes(v))
+    @test axes(OffsetVector(v, :)) == axes(v)
+
+    w = zeros(5:6)
+    @test OffsetVector(w, :) == OffsetArray(w, (:,)) == OffsetArray(w, :) == OffsetArray(w, axes(w))
+    @test axes(OffsetVector(w, :)) == axes(w)
 end
 
 @testset "OffsetMatrix constructors" begin
@@ -119,6 +124,13 @@ end
     @test OffsetMatrix(v, :, :) == OffsetArray(v, (:, :)) == OffsetArray(v, :, :) == OffsetArray(v, axes(v))
     @test OffsetMatrix(v, :, 2:4) == OffsetArray(v, axes(v,1), 2:4)
     @test OffsetMatrix(v, 3:7, :) == OffsetArray(v, 3:7, axes(v,2))
+    @test axes(OffsetArray(v, :, :)) == axes(v)
+
+    w = zeros(3:4, 5:6)
+    @test OffsetMatrix(w, :, :) == OffsetArray(w, (:, :)) == OffsetArray(w, :, :) == OffsetArray(w, axes(w))
+    @test OffsetMatrix(w, :, 2:3) == OffsetArray(w, axes(w,1), 2:3)
+    @test OffsetMatrix(w, 0:1, :) == OffsetArray(w, 0:1, axes(w,2))
+    @test axes(OffsetArray(w, :, :)) == axes(w)
 end
 
 @testset "undef, missing, and nothing constructors" begin


### PR DESCRIPTION
In case certain axes of an array are not offset, they may be implicitly specified using `Colon`s in the constructor. The colons would be replaced by the corresponding axes of the parent array.

```julia
julia> OffsetArray(zeros(2,3), :, 4:6)
2×3 OffsetArray(::Array{Float64,2}, 1:2, 4:6) with eltype Float64 with indices 1:2×4:6:
 0.0  0.0  0.0
 0.0  0.0  0.0
``` 

This is useful in cases where the size along a non-offset dimension is not known a-priori.