### PR TITLE
meta project quality test with Aqua

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,11 @@ version = "1.1.3"
 julia = "0.7, 1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CatIndices", "DelimitedFiles", "Test", "LinearAlgebra"]
+test = ["Aqua", "CatIndices", "DelimitedFiles", "Test", "LinearAlgebra"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,16 @@
-using OffsetArrays
 using Test
-using DelimitedFiles
-using OffsetArrays: IdentityUnitRange, no_offset_view
-using CatIndices: BidirectionalVector
 using LinearAlgebra
+using DelimitedFiles
+using CatIndices: BidirectionalVector
 
-@test isempty(detect_ambiguities(OffsetArrays, Base, Core))
+refambs = detect_ambiguities(Base, Core)
+
+using OffsetArrays
+using OffsetArrays: IdentityUnitRange, no_offset_view
+
+# make sure OffsetArrays doesn't contribute more ambiguities
+ambs = detect_ambiguities(OffsetArrays, Base, Core)
+@test length(setdiff(ambs, refambs)) == 0
 
 @testset "IdOffsetRange" begin
     function same_value(r1, r2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,14 @@
-using Test
+using OffsetArrays
+using OffsetArrays: IdentityUnitRange, no_offset_view
+using Test, Aqua
 using LinearAlgebra
 using DelimitedFiles
 using CatIndices: BidirectionalVector
 
-refambs = detect_ambiguities(Base, Core)
-
-using OffsetArrays
-using OffsetArrays: IdentityUnitRange, no_offset_view
-
-# make sure OffsetArrays doesn't contribute more ambiguities
-ambs = detect_ambiguities(OffsetArrays, Base, Core)
-@test length(setdiff(ambs, refambs)) == 0
+@testset "Project meta quality checks" begin
+    # Not checking compat section for test-only dependencies
+    Aqua.test_all(OffsetArrays; project_extras=true, deps_compat=true, stale_deps=true, project_toml_formatting=true)
+end
 
 @testset "IdOffsetRange" begin
     function same_value(r1, r2)


### PR DESCRIPTION
How ambiguity is computed is changed in https://github.com/JuliaLang/julia/pull/36962

For the purpose of ambiguity check for this package, it would be pretty much sufficient to only check that we don't contribute more ambiguities to Base and Core.

Aqua is used, instead, to free us from manually maintaining these meta project quality tests.