### PR TITLE
Add constructors for CartesianIndices

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -94,7 +94,7 @@ OffsetArray(A::AbstractArray{T,N}, inds::Vararg{Union{AbstractUnitRange, Cartesi
 # Extract the range r from CartesianIndices((r,))
 function stripCartesianIndices(inds::Tuple{CartesianIndices{1},Vararg{Any}})
     I = first(inds)
-    Ir = first(I.indices)
+    Ir = convert(Tuple{AbstractUnitRange{Int}}, I) |> first
     (Ir, stripCartesianIndices(tail(inds))...)
 end
 stripCartesianIndices(inds::Tuple)= (first(inds), stripCartesianIndices(tail(inds))...)


### PR DESCRIPTION
Fixes #71 . With this PR the following are possible:

```julia
julia> OffsetArray{Float64}(undef, CartesianIndex(3,4,-1):CartesianIndex(4,4,0))
2×1×2 OffsetArray(::Array{Float64,3}, 3:4, 4:4, -1:0) with eltype Float64 with indices 3:4×4:4×-1:0:
[:, :, -1] =
 6.93496739309444e-310
 6.93493894159696e-310

[:, :, 0] =
 6.9349593623032e-310
 6.93496425153495e-310

julia> v = rand(2,2,2);

julia> OffsetArray(v, :, CartesianIndex(2,2):CartesianIndex(3,3))
2×2×2 OffsetArray(::Array{Float64,3}, 1:2, 2:3, 2:3) with eltype Float64 with indices 1:2×2:3×2:3:
[:, :, 2] =
 0.679194  0.0652147
 0.684409  0.968799

[:, :, 3] =
 0.654027  0.599548
 0.665052  0.75195

julia> OffsetArray(v, :, CartesianIndex(2):CartesianIndex(3), 4:5)
2×2×2 OffsetArray(::Array{Float64,3}, 1:2, 2:3, 4:5) with eltype Float64 with indices 1:2×2:3×4:5:
[:, :, 4] =
 0.679194  0.0652147
 0.684409  0.968799

[:, :, 5] =
 0.654027  0.599548
 0.665052  0.75195
```

~~Not too sure if `CartesianIndices(..).indices` is future-proof.~~