### PR TITLE
add offset overflow check

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -24,9 +24,10 @@ OffsetVector{T,AA<:AbstractArray} = OffsetArray{T,1,AA}
 OffsetMatrix{T,AA<:AbstractArray} = OffsetArray{T,2,AA}
 
 function overflow_check(r, offset::T) where T
-    throw_offseterror() = throw(ArgumentError("Boundary overflow detected: offset $offset should be smaller than $(typemax(T) - last(r))"))
     if offset > 0 && last(r) > typemax(T) - offset
-        throw_offseterror()
+        throw(ArgumentError("Boundary overflow detected: offset $offset should be equal or less than $(typemax(T) - last(r))"))
+    elseif offset < 0 && first(r) < typemin(T) - offset
+        throw(ArgumentError("Boundary overflow detected: offset $offset should be equal or greater than $(typemin(T) - first(r))"))
     end
 end
 ## OffsetArray constructors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,6 +129,10 @@ end
 
     @test axes(OffsetVector(v, typemax(Int)-length(v))) == (IdOffsetRange(axes(v)[1], typemax(Int)-length(v)), )
     @test_throws ArgumentError OffsetVector(v, typemax(Int)-length(v)+1)
+    ao = OffsetArray(v, typemin(Int))
+    @test_nowarn OffsetArray{Float64, 1, typeof(ao)}(ao, (-1, ))
+    @test_throws ArgumentError OffsetArray{Float64, 1, typeof(ao)}(ao, (-2, )) # inner Constructor
+    @test_throws ArgumentError OffsetArray(ao, (-2, )) # convinient constructor accumulate offsets
 end
 
 @testset "OffsetMatrix constructors" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using OffsetArrays
 using OffsetArrays: IdentityUnitRange, no_offset_view
+using OffsetArrays: IdOffsetRange
 using Test, Aqua
 using LinearAlgebra
 using DelimitedFiles
@@ -125,6 +126,9 @@ end
     w = zeros(5:6)
     @test OffsetVector(w, :) == OffsetArray(w, (:,)) == OffsetArray(w, :) == OffsetArray(w, axes(w))
     @test axes(OffsetVector(w, :)) == axes(w)
+
+    @test axes(OffsetVector(v, typemax(Int)-length(v))) == (IdOffsetRange(axes(v)[1], typemax(Int)-length(v)), )
+    @test_throws ArgumentError OffsetVector(v, typemax(Int)-length(v)+1)
 end
 
 @testset "OffsetMatrix constructors" begin
@@ -158,6 +162,10 @@ end
 
     @test axes(OffsetMatrix(w, :, CartesianIndices((0:1,)))) == (3:4, 0:1)
     @test axes(OffsetMatrix(w, CartesianIndices((0:1,)), :)) == (0:1, 5:6)
+
+    @test axes(OffsetMatrix(v, typemax(Int)-size(v, 1), 0)) == (IdOffsetRange(axes(v)[1], typemax(Int)-size(v, 1)), axes(v, 2))
+    @test_throws ArgumentError OffsetMatrix(v, typemax(Int)-size(v,1)+1, 0)
+    @test_throws ArgumentError OffsetMatrix(v, 0, typemax(Int)-size(v, 2)+1)
 end
 
 @testset "construct OffsetArray with CartesianIndices" begin


### PR DESCRIPTION
Although this is related to overflow behavior in IdOffsetRange, the better place to raise an error is at the construction time of OffsetArray.

```julia
julia> a = rand(10);

julia> ao = OffsetArray(a, typemax(Int)-1)
ERROR: ArgumentError: Boundary overflow detected: offset 9223372036854775806 should be smaller than 9223372036854775797
```


Performance overhead should be acceptable:

```julia
a = zeros(5,5,5,5);

# Before: 14.129 ns (0 allocations: 0 bytes)
@btime OffsetArray($a, -2:2, -2:2, -2:2, -2:2);

# After: 15.952 ns (0 allocations: 0 bytes)
@btime OffsetArray($a, -2:2, -2:2, -2:2, -2:2);
```

closes #136 