### PR TITLE
optimize overflow_check

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -24,12 +24,17 @@ OffsetVector{T,AA<:AbstractArray} = OffsetArray{T,1,AA}
 OffsetMatrix{T,AA<:AbstractArray} = OffsetArray{T,2,AA}
 
 function overflow_check(r, offset::T) where T
+    # This gives some performance boost https://github.com/JuliaLang/julia/issues/33273
+    throw_upper_overflow_error() = throw(ArgumentError("Boundary overflow detected: offset $offset should be equal or less than $(typemax(T) - last(r))"))
+    throw_lower_overflow_error() = throw(ArgumentError("Boundary overflow detected: offset $offset should be equal or greater than $(typemin(T) - first(r))"))
+
     if offset > 0 && last(r) > typemax(T) - offset
-        throw(ArgumentError("Boundary overflow detected: offset $offset should be equal or less than $(typemax(T) - last(r))"))
+        throw_upper_overflow_error()
     elseif offset < 0 && first(r) < typemin(T) - offset
-        throw(ArgumentError("Boundary overflow detected: offset $offset should be equal or greater than $(typemin(T) - first(r))"))
+        throw_lower_overflow_error()
     end
 end
+
 ## OffsetArray constructors
 
 offset(axparent::AbstractUnitRange, ax::AbstractUnitRange) = first(ax) - first(axparent)


### PR DESCRIPTION
Even with https://github.com/JuliaLang/julia/issues/37558 fixed, it seems we still need such optimization to minimize the overhead in overflow check.

```julia
# Version 1.6.0-DEV.965 (2020-09-18)

julia> a = zeros(5,5,5,5);

# with overflow check (master)
julia> @btime OffsetArray($a, -2:2, -2:2, -2:2, -2:2);
  33.057 ns (0 allocations: 0 bytes)

# with overflow check (this PR)
julia> @btime OffsetArray($a, -2:2, -2:2, -2:2, -2:2);
  16.556 ns (0 allocations: 0 bytes)

# without overflow check
julia> @btime OffsetArray($a, -2:2, -2:2, -2:2, -2:2);
  13.515 ns (0 allocations: 0 bytes)
```