### PR TITLE
fix reshape on non-vector arrays

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -230,7 +230,8 @@ Base.reshape(A::OffsetArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}}) =
 # And for non-offset axes, we can just return a reshape of the parent directly
 Base.reshape(A::OffsetArray, inds::Tuple{Union{Integer,Base.OneTo},Vararg{Union{Integer,Base.OneTo}}}) = reshape(parent(A), inds)
 Base.reshape(A::OffsetArray, inds::Dims) = reshape(parent(A), inds)
-Base.reshape(A::OffsetArray, ::Colon) = A
+Base.reshape(A::OffsetArray, ::Colon) = reshape(parent(A), Colon())
+Base.reshape(A::OffsetVector, ::Colon) = A
 Base.reshape(A::OffsetArray, inds::Union{Int,Colon}...) = reshape(parent(A), inds)
 Base.reshape(A::OffsetArray, inds::Tuple{Vararg{Union{Int,Colon}}}) = reshape(parent(A), inds)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -614,6 +614,23 @@ end
 
     @test reshape(OffsetArray(-1:0, -1:0), :, 1) == reshape(-1:0, 2, 1)
     @test reshape(OffsetArray(-1:2, -1:2), -2:-1, :) == reshape(-1:2, -2:-1, 2)
+
+    @test reshape(OffsetArray(-1:0, -1:0), :) == OffsetArray(-1:0, -1:0)
+    @test reshape(A, :) == reshape(A0, :)
+
+    # julialang/julia #33614
+    A = OffsetArray(-1:0, (-2,))
+    @test reshape(A, :) === A
+    Arsc = reshape(A, :, 1)
+    Arss = reshape(A, 2, 1)
+    @test Arsc[1,1] == Arss[1,1] == -1
+    @test Arsc[2,1] == Arss[2,1] == 0
+    @test_throws BoundsError Arsc[0,1]
+    @test_throws BoundsError Arss[0,1]
+    A = OffsetArray([-1,0], (-2,))
+    Arsc = reshape(A, :, 1)
+    Arsc[1,1] = 5
+    @test first(A) == 5
 end
 
 @testset "Indexing with OffsetArray axes" begin


### PR DESCRIPTION
A bug introduced by #88 😮 

```julia
julia> using OffsetArrays

julia> A = rand(4, 4);

julia> reshape(A, :) |> axes
(Base.OneTo(16),)

julia> reshape(OffsetArray(A, 0, 0), :) |>  axes
(1:4, 1:4)
```

No new ambiguity here.