### PR TITLE
update compat patch version on #133

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -168,8 +168,9 @@ Base.show(io::IO, r::IdOffsetRange) = print(io, "OffsetArrays.IdOffsetRange(",fi
 # Optimizations
 @inline Base.checkindex(::Type{Bool}, inds::IdOffsetRange, i::Real) = Base.checkindex(Bool, inds.parent, i - inds.offset)
 
-if VERSION < v"1.6.0-DEV.762"
+if VERSION < v"1.5.2"
     # issue 100, 133: IdOffsetRange as another index-preserving case shouldn't comtribute offsets
+    # fixed by https://github.com/JuliaLang/julia/pull/37204
     @inline Base.compute_offset1(parent, stride1::Integer, dims::Tuple{Int}, inds::Tuple{IdOffsetRange}, I::Tuple) =
         Base.compute_linindex(parent, I) - stride1*first(inds[1])
 end


### PR DESCRIPTION
This bug fix is backported to v1.5.2 https://github.com/JuliaLang/julia/pull/37210

We could wait for Julia 1.5.2 release and then merge this.