### PR TITLE
Fix OutOfMemoryError in test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -196,8 +196,8 @@ end
     @test axes(y) == (IdentityUnitRange(-1:1),)
     @test eltype(y) === Float32
 
-    y = OffsetArray{Float64}(undef, -1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1)
-    @test axes(y) == (-1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1)
+    y = OffsetArray{Float64}(undef, -1:1, -7:7, -1:2, -5:5, -1:1, -3:3, -2:2, -1:1)
+    @test axes(y) == (-1:1, -7:7, -1:2, -5:5, -1:1, -3:3, -2:2, -1:1)
     @test eltype(y) === Float64
 
     for (T, t) in ((Missing, missing), (Nothing, nothing))
@@ -303,10 +303,10 @@ end
     @inbounds Ac[0,3,1] = 12
     @test Ac[0,3] == 12
 
-    y = OffsetArray{Float64}(undef, -1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1)
-    y[-1,-7,-128,-5,-1,-3,-2,-1] = 14
-    y[-1,-7,-128,-5,-1,-3,-2,-1] += 5
-    @test y[-1,-7,-128,-5,-1,-3,-2,-1] == 19
+    y = OffsetArray{Float64}(undef, -1:1, -7:7, -3:-1, -5:5, -1:1, -3:3, -2:2, -1:1)
+    y[-1,-7,-3,-5,-1,-3,-2,-1] = 14
+    y[-1,-7,-3,-5,-1,-3,-2,-1] += 5
+    @test y[-1,-7,-3,-5,-1,-3,-2,-1] == 19
 
     @testset "setindex!" begin
         A = OffsetArray(ones(2,2), 1:2, 1:2)


### PR DESCRIPTION
Not entirely sure if the array indices were chosen to satisfy any specific condition, but if they weren't then tests need not create such large arrays. 

Previously

```julia
julia> y = OffsetArray{Float64}(undef, -1:1, -7:7, -128:512, -5:5, -1:1, -3:3, -2:2, -1:1);

julia> Base.summarysize(y)/2^20 # size in MB
762.5423049926758
```

Now 

```julia
julia> y = OffsetArray{Float64}(undef, -1:1, -7:7, -1:2, -5:5, -1:1, -3:3, -2:2, -1:1);

julia> Base.summarysize(y)/2^20
4.75860595703125
```

This was leading to occasional `OutOfMemoryError`s while testing locally.