### PR TITLE
Make indexing idempotent again

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -305,12 +305,14 @@ const IIUR = IdentityUnitRange{S} where S<:AbstractUnitRange{T} where T<:Integer
 
 Base.step(a::OffsetRange) = step(parent(a))
 
-Base.getindex(a::OffsetRange, r::OffsetRange) = OffsetArray(a[parent(r)], r.offsets)
-function Base.getindex(a::OffsetRange, r::IdOffsetRange)
+@propagate_inbounds Base.getindex(a::OffsetRange, r::OffsetRange) = OffsetArray(a[parent(r)], r.offsets)
+@propagate_inbounds function Base.getindex(a::OffsetRange, r::IdOffsetRange)
     OffsetArray(a.parent[r.parent .+ (r.offset - a.offsets[1])], r.offset)
 end
-Base.getindex(a::OffsetRange, r::AbstractRange) = a.parent[r .- a.offsets[1]]
-Base.getindex(a::AbstractRange, r::OffsetRange) = OffsetArray(a[parent(r)], r.offsets)
+@propagate_inbounds Base.getindex(r::OffsetRange, s::IIUR) =
+    OffsetArray(r[s.indices], s)
+@propagate_inbounds Base.getindex(a::OffsetRange, r::AbstractRange) = a.parent[r .- a.offsets[1]]
+@propagate_inbounds Base.getindex(a::AbstractRange, r::OffsetRange) = OffsetArray(a[parent(r)], r.offsets)
 
 @propagate_inbounds Base.getindex(r::UnitRange, s::IIUR) =
     OffsetArray(r[s.indices], s)
@@ -318,12 +320,13 @@ Base.getindex(a::AbstractRange, r::OffsetRange) = OffsetArray(a[parent(r)], r.of
 @propagate_inbounds Base.getindex(r::StepRange, s::IIUR) =
     OffsetArray(r[s.indices], s)
 
-@inline @propagate_inbounds Base.getindex(r::StepRangeLen{T,<:Base.TwicePrecision,<:Base.TwicePrecision}, s::IIUR) where T =
-    OffsetArray(r[s.indices], s)
-@inline @propagate_inbounds Base.getindex(r::StepRangeLen{T}, s::IIUR) where {T} =
+@propagate_inbounds Base.getindex(r::StepRangeLen{T,<:Base.TwicePrecision,<:Base.TwicePrecision}, s::IIUR) where T =
     OffsetArray(r[s.indices], s)
 
-@inline @propagate_inbounds Base.getindex(r::LinRange, s::IIUR) =
+@propagate_inbounds Base.getindex(r::StepRangeLen{T}, s::IIUR) where {T} =
+    OffsetArray(r[s.indices], s)
+
+@propagate_inbounds Base.getindex(r::LinRange, s::IIUR) =
     OffsetArray(r[s.indices], s)
 
 function Base.show(io::IO, r::OffsetRange)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -320,6 +320,7 @@ end
 @propagate_inbounds Base.getindex(r::StepRange, s::IIUR) =
     OffsetArray(r[s.indices], s)
 
+# this method is needed for ambiguity resolution
 @propagate_inbounds Base.getindex(r::StepRangeLen{T,<:Base.TwicePrecision,<:Base.TwicePrecision}, s::IIUR) where T =
     OffsetArray(r[s.indices], s)
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -306,6 +306,9 @@ const IIUR = IdentityUnitRange{S} where S<:AbstractUnitRange{T} where T<:Integer
 Base.step(a::OffsetRange) = step(parent(a))
 
 Base.getindex(a::OffsetRange, r::OffsetRange) = OffsetArray(a[parent(r)], r.offsets)
+function Base.getindex(a::OffsetRange, r::IdOffsetRange)
+    OffsetArray(a.parent[r.parent .+ (r.offset - a.offsets[1])], r.offset)
+end
 Base.getindex(a::OffsetRange, r::AbstractRange) = a.parent[r .- a.offsets[1]]
 Base.getindex(a::AbstractRange, r::OffsetRange) = OffsetArray(a[parent(r)], r.offsets)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,6 +351,13 @@ end
     r1 = OffsetArray(8:10, -1:1)[OffsetArray(0:1, -5:-4)]
     @test axes(r1) == (IdentityUnitRange(-5:-4),)
     @test parent(r1) === 9:10
+
+    a = OffsetVector(3:4, 10:11)
+    ax = OffsetArrays.IdOffsetRange(5:6, 5)
+    @test axes(a[ax]) == axes(ax)
+    for i in axes(ax,1)
+        @test a[ax[i]] == a[ax][i]
+    end
 end
 
 @testset "CartesianIndexing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,8 +231,15 @@ end
     r = -2:5
     y = OffsetArray(r, r)
     @test axes(y) == (r,)
+    @test step(y) == step(r)
     y = OffsetArray(r, (r,))
     @test axes(y) == (r,)
+
+    s = -2:2:4
+    r = 5:8
+    y = OffsetArray(s, r)
+    @test axes(y) == (r,)
+    @test step(y) == step(s)
 end
 
 @testset "OffsetArray of OffsetArray construction" begin
@@ -664,7 +671,7 @@ end
     v = view(A0, 1:1, i1)
     @test axes(v) == (Base.OneTo(1), IdentityUnitRange(-4:-3))
 
-    for r in (1:10, 1:1:10, StepRangeLen(1, 1, 10), LinRange(1, 10, 10))
+    for r in (1:10, 1:1:10, StepRangeLen(1, 1, 10), LinRange(1, 10, 10), 0.1:0.2:0.9)
         for s in (IdentityUnitRange(2:3), OffsetArray(2:3, 2:3))
             @test axes(r[s]) == axes(s)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -358,6 +358,12 @@ end
     for i in axes(ax,1)
         @test a[ax[i]] == a[ax][i]
     end
+
+    ax = IdentityUnitRange(10:11)
+    @test axes(a[ax]) == axes(ax)
+    for i in axes(ax,1)
+        @test a[ax[i]] == a[ax][i]
+    end
 end
 
 @testset "CartesianIndexing" begin


### PR DESCRIPTION
This is a patchwork of fixes that address a couple of common cases encountered while indexing with offset axes.

Now
```julia
julia> a = OffsetVector(3:4, 10:11)
3:4 with indices 10:11

julia> ax = Base.IdentityUnitRange(10:11)
Base.IdentityUnitRange(10:11)

julia> a[ax]
3:4 with indices 10:11

julia> axes(a[ax]) == axes(ax)
true

julia> ax = OffsetArrays.IdOffsetRange(5:6, 5)
OffsetArrays.IdOffsetRange(10:11)

julia> a[ax]
3:4 with indices 6:7

julia> axes(a[ax]) == axes(ax)
true
```

This is not really a proper fix, as ideally we would want to return an `OffsetVector` when an `OffsetRange` is indexed using an arbitrary `AbstractUnitRange`. However that might be too breaking, so as of now I suppose this will have to do.

Fixes #155 