### PR TITLE
eltype and ndims of an OffsetArray matches that of the parent

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -89,10 +89,10 @@ julia> OffsetArray(a, OffsetArrays.Origin(0)) # short notation for `Origin(0, ..
 
 
 """
-struct OffsetArray{T,N,AA<:AbstractArray} <: AbstractArray{T,N}
+struct OffsetArray{T,N,AA<:AbstractArray{T,N}} <: AbstractArray{T,N}
     parent::AA
     offsets::NTuple{N,Int}
-    function OffsetArray{T, N, AA}(parent::AA, offsets::NTuple{N, Int}) where {T, N, AA<:AbstractArray}
+    function OffsetArray{T, N, AA}(parent::AA, offsets::NTuple{N, Int}) where {T, N, AA<:AbstractArray{T,N}}
         @boundscheck overflow_check.(axes(parent), offsets)
         new{T, N, AA}(parent, offsets)
     end
@@ -103,14 +103,14 @@ end
 
 Type alias and convenience constructor for one-dimensional [`OffsetArray`](@ref)s.
 """
-const OffsetVector{T,AA<:AbstractArray} = OffsetArray{T,1,AA}
+const OffsetVector{T,AA<:AbstractVector{T}} = OffsetArray{T,1,AA}
 
 """
     OffsetMatrix(A, index1, index2)
 
 Type alias and convenience constructor for two-dimensional [`OffsetArray`](@ref)s.
 """
-const OffsetMatrix{T,AA<:AbstractArray} = OffsetArray{T,2,AA}
+const OffsetMatrix{T,AA<:AbstractMatrix{T}} = OffsetArray{T,2,AA}
 
 function overflow_check(r, offset::T) where T
     # This gives some performance boost https://github.com/JuliaLang/julia/issues/33273

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -283,6 +283,11 @@ end
         @test_throws ArgumentError OffsetVector(zeros(2:3,2:3), (2, 4))
         @test_throws ArgumentError OffsetVector(zeros(2:3,2:3), ())
         @test_throws ArgumentError OffsetVector(zeros(2:3,2:3))
+
+        # eltype of an OffsetArray should match that of the parent (issue #162)
+        @test_throws TypeError OffsetVector{Float64,Vector{ComplexF64}}
+        # ndim of an OffsetArray should match that of the parent
+        @test_throws TypeError OffsetVector{Float64,Matrix{Float64}}
     end
 
     @testset "OffsetMatrix" begin
@@ -416,6 +421,11 @@ end
         @test_throws ArgumentError OffsetMatrix(zeros(2:3, 1:2, 1:2), 2,0,0)
         @test_throws ArgumentError OffsetMatrix(zeros(2:3, 1:2, 1:2), ())
         @test_throws ArgumentError OffsetMatrix(zeros(2:3, 1:2, 1:2))
+
+        # eltype of an OffsetArray should match that of the parent (issue #162)
+        @test_throws TypeError OffsetMatrix{Float64,Matrix{ComplexF64}}
+        # ndim of an OffsetArray should match that of the parent
+        @test_throws TypeError OffsetMatrix{Float64,Vector{Float64}}
     end
 
     # no need to duplicate the 2D case here,
@@ -466,6 +476,11 @@ end
                 @test eltype(a) == Bool
             end
         end
+
+        # eltype of an OffsetArray should match that of the parent (issue #162)
+        @test_throws TypeError OffsetArray{Float64,2,Matrix{ComplexF64}}
+        # ndim of an OffsetArray should match that of the parent
+        @test_throws TypeError OffsetArray{Float64,3,Matrix{Float64}}
     end
 
     @testset "custom range types" begin


### PR DESCRIPTION
Fixes #162 

Now 

```julia
julia> OffsetMatrix{Float64, Matrix{ComplexF64}}
ERROR: TypeError: in Type, in AA, expected AA<:AbstractArray{Float64,2}, got Type{Array{Complex{Float64},2}}
```

also,

```julia
julia> OffsetMatrix{Float64, Vector{Float64}}
ERROR: TypeError: in Type, in AA, expected AA<:AbstractArray{Float64,2}, got Type{Array{Float64,1}}
```