### PR TITLE
inline OffsetArray constructors

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -93,7 +93,7 @@ struct OffsetArray{T,N,AA<:AbstractArray{T,N}} <: AbstractArray{T,N}
     parent::AA
     offsets::NTuple{N,Int}
     function OffsetArray{T, N, AA}(parent::AA, offsets::NTuple{N, Int}) where {T, N, AA<:AbstractArray{T,N}}
-        # `map` on tuple can be optimized by the compiler and thus not using `foreach` here
+        # allocation of `map` on tuple is optimized away
         map(overflow_check, axes(parent), offsets)
         new{T, N, AA}(parent, offsets)
     end

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -93,7 +93,8 @@ struct OffsetArray{T,N,AA<:AbstractArray{T,N}} <: AbstractArray{T,N}
     parent::AA
     offsets::NTuple{N,Int}
     function OffsetArray{T, N, AA}(parent::AA, offsets::NTuple{N, Int}) where {T, N, AA<:AbstractArray{T,N}}
-        overflow_check.(axes(parent), offsets)
+        # `map` on tuple can be optimized by the compiler and thus not using `foreach` here
+        map(overflow_check, axes(parent), offsets)
         new{T, N, AA}(parent, offsets)
     end
 end


### PR DESCRIPTION
To reduce the overhead

```julia
julia> a = zeros(5,5,5,5);

julia> @btime OffsetArray($a, -2:2, -2:2, -2:2, -2:2);
  3.088 ns (0 allocations: 0 bytes) # this PR; 1.5.2
  2.463 ns (0 allocations: 0 bytes) # this PR; 1.6-dev
  16.180 ns (0 allocations: 0 bytes) # master; 1.5.2
  15.693 ns (0 allocations: 0 bytes) # master; 1.6-dev
```