### PR TITLE
similar(T, axes) does not accept colons

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -234,7 +234,7 @@ Base.reshape(A::OffsetVector, ::Colon) = A
 Base.reshape(A::OffsetArray, inds::Union{Int,Colon}...) = reshape(parent(A), inds)
 Base.reshape(A::OffsetArray, inds::Tuple{Vararg{Union{Int,Colon}}}) = reshape(parent(A), inds)
 
-function Base.similar(::Type{T}, shape::Tuple{OffsetAxis,Vararg{OffsetAxis}}) where {T<:AbstractArray}
+function Base.similar(::Type{T}, shape::Tuple{OffsetAxisKnownLength,Vararg{OffsetAxisKnownLength}}) where {T<:AbstractArray}
     P = T(undef, map(_indexlength, shape))
     OffsetArray(P, map(_offset, axes(P), shape))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -969,6 +969,10 @@ end
     @test_throws MethodError similar(A, (: ,2))
     @test_throws MethodError similar(A, Float64, (: ,:))
     @test_throws MethodError similar(A, Float64, (: ,2))
+
+    @test_throws MethodError similar(Matrix{Float64}, (:, 2))
+    @test_throws MethodError similar(Matrix{Float64}, (:, 1:3))
+    @test_throws MethodError similar(Matrix{Float64}, (:, :))
 end
 
 @testset "reshape" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -970,9 +970,21 @@ end
     @test_throws MethodError similar(A, Float64, (: ,:))
     @test_throws MethodError similar(A, Float64, (: ,2))
 
-    @test_throws MethodError similar(Matrix{Float64}, (:, 2))
-    @test_throws MethodError similar(Matrix{Float64}, (:, 1:3))
-    @test_throws MethodError similar(Matrix{Float64}, (:, :))
+    function testsimilar(args...)
+        try
+           similar(args...)
+        catch e
+            @test e isa MethodError
+            io = IOBuffer()
+            showerror(io, e)
+            s = split(String(take!(io)),'\n')[1]
+            @test occursin(repr(similar), s)
+        end
+    end
+
+    testsimilar(typeof(A), (:, :))
+    testsimilar(typeof(A), (:, 2))
+    testsimilar(typeof(A), (:, 1:3))
 end
 
 @testset "reshape" begin


### PR DESCRIPTION
Looks like this was missed out in #126 . This improves the error message (it's still a `MethodError`).

before:
```julia
julia> similar(Matrix{Float64}, (:, :))
ERROR: MethodError: no method matching Array{Float64,2}(::UndefInitializer, ::Tuple{Colon,Colon})
```

after:
```julia
julia> similar(Matrix{Float64}, (:, :))
ERROR: MethodError: no method matching similar(::Type{Array{Float64,2}}, ::Tuple{Colon,Colon})
```
