### PR TITLE
Avoid returning the value of toplevel in Base.showarg

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -360,7 +360,9 @@ function Base.showarg(io::IO, a::OffsetArray, toplevel)
     Base.showarg(io, parent(a), false)
     Base.showindices(io, axes(a)...)
     print(io, ')')
-    toplevel && print(io, " with eltype ", eltype(a))
+    if toplevel
+        print(io, " with eltype ", eltype(a))
+    end
 end
 
 function Base.replace_in_print_matrix(A::OffsetArray{<:Any,2}, i::Integer, j::Integer, s::AbstractString)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -929,6 +929,12 @@ end
     v = rand(3)
     ov = OffsetArray(v, (-2,))
     @test Base.replace_in_print_matrix(ov, -1, 1, " ") == Base.replace_in_print_matrix(v, 1, 1, " ")
+
+    # Avoid returning the value of toplevel if it is false
+    # showarg should only print values, it shouldn't return anything
+    @test Base.showarg(io, a, false) === nothing
+    # check the other case too for good measure
+    @test Base.showarg(io, a, true) === nothing
 end
 
 @testset "readdlm/writedlm" begin


### PR DESCRIPTION
Currently:

```julia
julia> Base.showarg(stdout, zeros(1:2, 2:2), false)
OffsetArray(::Array{Float64,2}, 1:2, 2:2)false
```

Note the `false` at the end? That happens because `toplevel && print(io, ...)` evaluates to false, and the returned value is printed :smile:.  Shifted to an `if-else` block to avoid this. This also makes the function type-stable.

Now:

```julia
julia> Base.showarg(stdout, zeros(1:2, 2:2), false)
OffsetArray(::Array{Float64,2}, 1:2, 2:2)
```