### PR TITLE
avoid dynamic dispatch in no_offset_view(::Array)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -377,9 +377,9 @@ end
 """
     no_offset_view(A)
 
-Return an `AbstractArray` that shares structure and has the same type and size as the
-argument, but has 1-based indexing. May just return the argument when applicable. Not
-exported.
+Return an `AbstractArray` that shares structure and underlying data with the argument,
+but uses 1-based indexing. May just return the argument when applicable.
+Not exported.
 
 The default implementation uses `OffsetArrays`, but other types should use something more
 specific to remove a level of indirection when applicable.
@@ -403,14 +403,14 @@ julia> A
 """
 function no_offset_view(A::AbstractArray)
     if Base.has_offset_axes(A)
-        OffsetArray(A, map(r->1-first(r), axes(A)))
+        OffsetArray(A, Origin(1))
     else
         A
     end
 end
 
 no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
-
+no_offset_view(a::Array) = a
 
 ####
 # work around for segfault in searchsorted*

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1309,6 +1309,13 @@ function Base.getindex(A::NegativeArray{T,N}, I::Vararg{Int,N}) where {T,N}
     getindex(A.parent, (I .+ size(A.parent) .+ 1)...)
 end
 
+struct PointlessWrapper{T,N, A <: AbstractArray{T,N}} <: AbstractArray{T,N}
+    parent :: A
+end
+Base.parent(x::PointlessWrapper) = x.parent
+Base.size(x::PointlessWrapper) = size(parent(x))
+Base.axes(x::PointlessWrapper) = axes(parent(x))
+
 @testset "no offset view" begin
     # OffsetArray fallback
     A = randn(3, 3)
@@ -1318,6 +1325,9 @@ end
     @test no_offset_view(O2) ≡ A
     @inferred no_offset_view(O1)
     @inferred no_offset_view(O2)
+
+    P = PointlessWrapper(A)
+    @test no_offset_view(P) ≡ P
 
     # generic fallback
     A = collect(reshape(1:12, 3, 4))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1312,9 +1312,12 @@ end
 @testset "no offset view" begin
     # OffsetArray fallback
     A = randn(3, 3)
+    @inferred no_offset_view(A)
     O1 = OffsetArray(A, -1:1, 0:2)
     O2 = OffsetArray(O1, -2:0, -3:(-1))
     @test no_offset_view(O2) ≡ A
+    @inferred no_offset_view(O1)
+    @inferred no_offset_view(O2)
 
     # generic fallback
     A = collect(reshape(1:12, 3, 4))


### PR DESCRIPTION
This is a common case, so it might be worth the specialized method. Seems to cut down on allocations in certain applications, although the performance gain appears to be minimal.

On master: 

```julia
julia> a = zeros(0:1000, 0:1000);

julia> function f(a)
       x = OffsetArrays.no_offset_view(a)
       sum(x[i] for i = 1:lastindex(x))
       end
f (generic function with 1 method)

julia> @btime f($a);
  1.701 ms (4 allocations: 96 bytes)
``` 

After this PR: 

```julia
julia> @btime f($a);
  1.684 ms (0 allocations: 0 bytes)
```

Also uses `Origin` in the constructor to make it simpler.  