### PR TITLE
Embrace pairs for `show` and construction

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -44,7 +44,7 @@ julia> axes(ro, 1)     # 11:13 is indexed by 1:3, and the offset is also applied
 
 You can construct these ranges as they are displayed:
 
-```jldoctest; setup=(import OffsetArrays)
+```jldoctest; setup=(import OffsetArrays), filter=r", ?U"
 julia> r = (0=>8):(3=>11)
 (0 => 8):(3 => 11)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,6 +101,14 @@ end
     r = IdOffsetRange(IdOffsetRange(3:5, 2), 1)
     @test parent(r) isa UnitRange
 
+    # Pair construction
+    rp = (2=>3):(5=>6)
+    @test first(rp) === 3
+    @test  last(rp) === 6
+    @test firstindex(rp) === 2
+    @test  lastindex(rp) === 5
+    @test_throws ArgumentError("indices and values must have the same length, got 0:1 (length 2) and 5:7 (length 3), respectively") (0=>5):(1=>7)
+
     # conversion preserves both the values and the axes, throwing an error if this is not possible
     @test @inferred(oftype(ro, ro)) === ro
     @test @inferred(convert(OffsetArrays.IdOffsetRange{Int}, ro)) === ro
@@ -199,19 +207,19 @@ end
     @testset "OffsetVector" begin
         # initialization
         one_based_axes = [
-            (Base.OneTo(4), ), 
-            (1:4, ), 
-            (CartesianIndex(1):CartesianIndex(4), ), 
-            (IdentityUnitRange(1:4), ), 
-            (IdOffsetRange(1:4),), 
+            (Base.OneTo(4), ),
+            (1:4, ),
+            (CartesianIndex(1):CartesianIndex(4), ),
+            (IdentityUnitRange(1:4), ),
+            (IdOffsetRange(1:4),),
             (IdOffsetRange(3:6, -2),)
         ]
 
         offset_axes = [
-            (-1:2, ), 
-            (CartesianIndex(-1):CartesianIndex(2), ), 
-            (IdentityUnitRange(-1:2), ), 
-            (IdOffsetRange(-1:2),), 
+            (-1:2, ),
+            (CartesianIndex(-1):CartesianIndex(2), ),
+            (IdentityUnitRange(-1:2), ),
+            (IdOffsetRange(-1:2),),
             (IdOffsetRange(3:6, -4),)
         ]
 
@@ -324,7 +332,7 @@ end
 
     @testset "OffsetMatrix" begin
         # initialization
-        
+
         one_based_axes = [
                 (Base.OneTo(4), Base.OneTo(3)),
                 (1:4, 1:3),
@@ -573,7 +581,7 @@ end
         end
         @testset "TupleOfRanges" begin
             Base.to_indices(A, inds, t::Tuple{TupleOfRanges{N}}) where {N} = t
-            OffsetArrays.AxisConversionStyle(::Type{TupleOfRanges{N}}) where {N} = 
+            OffsetArrays.AxisConversionStyle(::Type{TupleOfRanges{N}}) where {N} =
                 OffsetArrays.TupleOfRanges()
 
             Base.convert(::Type{Tuple{Vararg{AbstractUnitRange{Int}}}}, t::TupleOfRanges) = t.x
@@ -584,7 +592,7 @@ end
             @test axes(oa) == inds.x
         end
         @testset "NewColon" begin
-            Base.to_indices(A, inds, t::Tuple{NewColon,Vararg{Any}}) = 
+            Base.to_indices(A, inds, t::Tuple{NewColon,Vararg{Any}}) =
                 (_uncolon(inds, t), to_indices(A, Base.tail(inds), Base.tail(t))...)
 
             _uncolon(inds::Tuple{}, I::Tuple{NewColon, Vararg{Any}}) = OneTo(1)
@@ -916,9 +924,9 @@ end
     a = OffsetArray([1 2; 3 4], -1:0, 5:6)
     io = IOBuffer()
     show(io, axes(a, 1))
-    @test String(take!(io)) == "OffsetArrays.IdOffsetRange(-1:0)"
+    @test String(take!(io)) == "(-1 => -1):(0 => 0)"
     show(io, axes(a, 2))
-    @test String(take!(io)) == "OffsetArrays.IdOffsetRange(5:6)"
+    @test String(take!(io)) == "(5 => 5):(6 => 6)"
 
     @test Base.inds2string(axes(a)) == Base.inds2string(map(UnitRange, axes(a)))
 


### PR DESCRIPTION
This changes the `show` method for `IdOffsetRange` to print as follows:

```julia
julia> using OffsetArrays: IdOffsetRange

julia> IdOffsetRange(3:5, 1)
(2 => 4):(4 => 6)
```

It allows you to construct them as displayed:
```julia
julia> for p in pairs( (0=>5):(2=>7) )
           println(p)
       end
0 => 5
1 => 6
2 => 7
```

The advantage is that this makes both the indexes and the values apparent.
It fixes the problem that two ranges with different indexes currently print the same:

```julia
julia> r1 = IdOffsetRange(0:2, 0)
OffsetArrays.IdOffsetRange(0:2)

julia> firstindex(r1)
1

julia> r2 = IdOffsetRange(Base.IdentityUnitRange(-1:1), 1)
OffsetArrays.IdOffsetRange(0:2)

julia> firstindex(r2)
0
```