### PR TITLE
Bugfix in dispatch in IdOffsetRange{T,I}(::IdOffsetRange{T,I})

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.4.3"
+version = "1.4.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -93,7 +93,7 @@ IdOffsetRange(r::AbstractUnitRange{T}, offset::Integer = 0) where T<:Integer =
     IdOffsetRange{T,typeof(r)}(r, convert(T, offset))
 
 # Coercion from other IdOffsetRanges
-IdOffsetRange{T,I}(r::IdOffsetRange{T,I}) where {T,I} = r
+IdOffsetRange{T,I}(r::IdOffsetRange{T,I}) where {T<:Integer,I<:AbstractUnitRange{T}} = r
 function IdOffsetRange{T,I}(r::IdOffsetRange, offset::Integer = 0) where {T<:Integer,I<:AbstractUnitRange{T}}
     rc, offset_rc = offset_coerce(I, r.parent)
     return IdOffsetRange{T,I}(rc, r.offset + offset + offset_rc)


### PR DESCRIPTION
I had inadvertently altered the method signature of `IdOffsetRange{T,I}(::IdOffsetRange{T,I})` in #178 . This should be a no-op. This PR reverts it.