### PR TITLE
Conditionally skip CI for non-breaking changes

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -6,7 +6,15 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'LICENSE.md'
+      - 'README.md'
+      - '.github/workflows/TagBot.yml'
   pull_request:
+    paths-ignore:
+      - 'LICENSE.md'
+      - 'README.md'
+      - '.github/workflows/TagBot.yml'
   schedule:
     - cron: '20 00 1 * *'
 


### PR DESCRIPTION
Skip CI if changes are made only to readme, license or Tagbot configurations