### PR TITLE
A bit of SnoopCompile-inspired maintenance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "1.5.0"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 
 [compat]
-Adapt = "2"
+Adapt = "2, 3"
 julia = "0.7, 1"
 
 [extras]

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -509,4 +509,9 @@ end
 import Adapt
 Adapt.adapt_structure(to, x::OffsetArray) = OffsetArray(Adapt.adapt(to, parent(x)), x.offsets)
 
+if Base.VERSION >= v"1.4.2"
+    include("precompile.jl")
+    _precompile_()
+end
+
 end # module

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -24,14 +24,14 @@ const ArrayInitializer = Union{UndefInitializer, Missing, Nothing}
     OffsetArray(A, indices...)
 
 Return an `AbstractArray` that shares element type and size with the first argument but
-uses the supplied `indices` to infer its axes. If all the indices are `AbstractUnitRange`s then 
-these are directly used as the axis span along each dimension. Refer to the examples below for other 
+uses the supplied `indices` to infer its axes. If all the indices are `AbstractUnitRange`s then
+these are directly used as the axis span along each dimension. Refer to the examples below for other
 permissible types.
 
-Alternatively it's possible to specify the coordinates of one corner of the array 
-and have the axes be computed automatically from the size of `A`. 
+Alternatively it's possible to specify the coordinates of one corner of the array
+and have the axes be computed automatically from the size of `A`.
 This constructor makes it convenient to shift to
-an arbitrary starting index along each axis, for example to a zero-based indexing scheme followed by 
+an arbitrary starting index along each axis, for example to a zero-based indexing scheme followed by
 arrays in languages such as C and Python.
 See [`Origin`](@ref) and the examples below for this usage.
 
@@ -51,9 +51,9 @@ julia> A[0, 1]
 5
 ```
 
-Examples of range-like types are: `UnitRange` (e.g, `-1:2`), `CartesianIndices`, 
-and `Colon()` (or concisely `:`). A `UnitRange` specifies the axis span along one particular dimension, 
-`CartesianIndices` specify the axis spans along multiple dimensions, and a `Colon` is a placeholder 
+Examples of range-like types are: `UnitRange` (e.g, `-1:2`), `CartesianIndices`,
+and `Colon()` (or concisely `:`). A `UnitRange` specifies the axis span along one particular dimension,
+`CartesianIndices` specify the axis spans along multiple dimensions, and a `Colon` is a placeholder
 that specifies that the `OffsetArray` shares its axis with its parent along that dimension.
 
 ```jldoctest; setup=:(using OffsetArrays)
@@ -86,9 +86,9 @@ ERROR: [...]
 
 # Example: origin
 
-[`OffsetArrays.Origin`](@ref) may be used to specify the origin of the OffsetArray. The term origin here 
-refers to the corner with the lowest values of coordinates, such as the left edge for an `AbstractVector`, 
-the bottom left corner for an `AbstractMatrix` and so on. The coordinates of the origin sets the starting 
+[`OffsetArrays.Origin`](@ref) may be used to specify the origin of the OffsetArray. The term origin here
+refers to the corner with the lowest values of coordinates, such as the left edge for an `AbstractVector`,
+the bottom left corner for an `AbstractMatrix` and so on. The coordinates of the origin sets the starting
 index of the array along each dimension.
 
 ```jldoctest; setup=:(using OffsetArrays)
@@ -150,7 +150,7 @@ end
     OffsetArray{eltype(A), ndims(A), typeof(A)}(A, offsets)
 end
 
-# These methods are necessary to disallow incompatible dimensions for 
+# These methods are necessary to disallow incompatible dimensions for
 # the OffsetVector and the OffsetMatrix constructors
 for (FT, ND) in ((:OffsetVector, :1), (:OffsetMatrix, :2))
     @eval @inline function $FT(A::AbstractArray{<:Any,$ND}, offsets::Tuple{Vararg{Integer}})
@@ -185,7 +185,7 @@ for FT in (:OffsetArray, :OffsetVector, :OffsetMatrix)
         lA = size(A)
         lI = map(length, inds)
         lA == lI || throw_dimerr(lA, lI)
-        $FT(A, map(_offset, axes(A), inds)) 
+        $FT(A, map(_offset, axes(A), inds))
     end
 
     @eval @inline $FT(A::AbstractArray, inds::Vararg) = $FT(A, inds)
@@ -372,7 +372,7 @@ function Base.inds2string(inds::Tuple{Vararg{Union{IdOffsetRange, IdentityUnitRa
     Base.inds2string(map(UnitRange, inds))
 end
 Base.showindices(io::IO, ind1::IdOffsetRange, inds::IdOffsetRange...) = Base.showindices(io, map(UnitRange, (ind1, inds...))...)
-    
+
 function Base.showarg(io::IO, a::OffsetArray, toplevel)
     print(io, "OffsetArray(")
     Base.showarg(io, parent(a), false)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -373,7 +373,7 @@ function Base.inds2string(inds::Tuple{Vararg{Union{IdOffsetRange, IdentityUnitRa
 end
 Base.showindices(io::IO, ind1::IdOffsetRange, inds::IdOffsetRange...) = Base.showindices(io, map(UnitRange, (ind1, inds...))...)
 
-function Base.showarg(io::IO, a::OffsetArray, toplevel)
+function Base.showarg(io::IO, @nospecialize(a::OffsetArray), toplevel)
     print(io, "OffsetArray(")
     Base.showarg(io, parent(a), false)
     Base.showindices(io, axes(a)...)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -178,3 +178,10 @@ if VERSION < v"1.5.2"
     @inline Base.compute_offset1(parent, stride1::Integer, dims::Tuple{Int}, inds::Tuple{IdOffsetRange}, I::Tuple) =
         Base.compute_linindex(parent, I) - stride1*first(inds[1])
 end
+
+# This was deemed "too private" to extend: see issue #184
+# # Fixes an inference failure in Base.mapfirst!
+# # Test: A = OffsetArray(rand(4,4), (-3,5)); R = similar(A, (1:1, 6:9)); maximum!(R, A)
+# if isdefined(Base, :_firstslice)
+#     Base._firstslice(i::IdOffsetRange) = IdOffsetRange(Base._firstslice(i.parent), i.offset)
+# end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,15 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    Base.precompile(Tuple{typeof(Base.showarg),IOBuffer,OffsetArray{Int, 0, Array{Int, 0}},Bool})   # time: 0.037824474
+    Base.precompile(Tuple{Type{IdOffsetRange{Int, Base.OneTo{Int}}},UnitRange{Int}})   # time: 0.009825722
+    Base.precompile(Tuple{typeof(Base.inds2string),Tuple{IdOffsetRange{Int, Base.OneTo{Int}}, IdOffsetRange{Int, Base.OneTo{Int}}}})   # time: 0.0080779
+    Base.precompile(Tuple{typeof(getindex),StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}},IdentityUnitRange{UnitRange{Int}}})   # time: 0.008055889
+    Base.precompile(Tuple{typeof(getindex),StepRangeLen{Int, Int, Int},IdentityUnitRange{UnitRange{Int}}})   # time: 0.006584347
+    Base.precompile(Tuple{typeof(getindex),StepRange{Int, Int},IdentityUnitRange{UnitRange{Int}}})   # time: 0.00650066
+    Base.precompile(Tuple{typeof(getindex),LinRange{Float64},IdentityUnitRange{UnitRange{Int}}})   # time: 0.005844317
+    Base.precompile(Tuple{typeof(zeros),Tuple{IdOffsetRange{Int, Base.OneTo{Int}}}})   # time: 0.007713056
+    Base.precompile(Tuple{typeof(ones),Tuple{IdOffsetRange{Int, Base.OneTo{Int}}}})   # time: 0.007713056
+    Base.precompile(Tuple{typeof(trues),Tuple{UnitRange{Int}, UnitRange{Int}}})   # time: 0.005478372
+    Base.precompile(Tuple{typeof(falses),Tuple{UnitRange{Int}, UnitRange{Int}}})   # time: 0.005478372
+    Base.precompile(Tuple{typeof(firstindex),IdOffsetRange{Int, Base.OneTo{Int}}})   # time: 0.004100289
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,24 +198,24 @@ end
 
     @testset "OffsetVector" begin
         # initialization
-        one_based_axes = [
-            (Base.OneTo(4), ), 
-            (1:4, ), 
-            (CartesianIndex(1):CartesianIndex(4), ), 
-            (IdentityUnitRange(1:4), ), 
-            (IdOffsetRange(1:4),), 
+        one_based_axes = Any[
+            (Base.OneTo(4), ),
+            (1:4, ),
+            (CartesianIndex(1):CartesianIndex(4), ),
+            (IdentityUnitRange(1:4), ),
+            (IdOffsetRange(1:4),),
             (IdOffsetRange(3:6, -2),)
         ]
 
-        offset_axes = [
-            (-1:2, ), 
-            (CartesianIndex(-1):CartesianIndex(2), ), 
-            (IdentityUnitRange(-1:2), ), 
-            (IdOffsetRange(-1:2),), 
+        offset_axes = Any[
+            (-1:2, ),
+            (CartesianIndex(-1):CartesianIndex(2), ),
+            (IdentityUnitRange(-1:2), ),
+            (IdOffsetRange(-1:2),),
             (IdOffsetRange(3:6, -4),)
         ]
 
-        for inds in [size.(one_based_axes[1], 1), one_based_axes...]
+        for inds in Any[size.(one_based_axes[1], 1), one_based_axes...]
             # test indices API
             a = OffsetVector{Float64}(undef, inds)
             @test eltype(a) === Float64
@@ -248,7 +248,7 @@ end
             a = OffsetVector{Missing}(missing, inds)
             @test axes(a) === ax
 
-            for (T, t) in [(Nothing, nothing), (Missing, missing)]
+            for (T, t) in Any[(Nothing, nothing), (Missing, missing)]
                 a = OffsetVector{Union{T, Vector{Int}}}(undef, inds)
                 @test !isassigned(a, -1)
                 @test eltype(a) === Union{T, Vector{Int}}
@@ -282,7 +282,7 @@ end
         # nested offset array
         a = rand(4)
         oa = OffsetArray(a, -1)
-        for inds in [.-oa.offsets, one_based_axes...]
+        for inds in Any[.-oa.offsets, one_based_axes...]
             ooa = OffsetArray(oa, inds)
             @test typeof(parent(ooa)) <: Vector
             @test ooa === OffsetArray(oa, inds...) === OffsetVector(oa, inds) === OffsetVector(oa, inds...)
@@ -324,8 +324,8 @@ end
 
     @testset "OffsetMatrix" begin
         # initialization
-        
-        one_based_axes = [
+
+        one_based_axes = Any[
                 (Base.OneTo(4), Base.OneTo(3)),
                 (1:4, 1:3),
                 (CartesianIndex(1, 1):CartesianIndex(4, 3), ),
@@ -338,7 +338,7 @@ end
                 (IdOffsetRange(3:6, -2), 1:3),
         ]
 
-        offset_axes = [
+        offset_axes = Any[
                 (-1:2, 0:2),
                 (CartesianIndex(-1, 0):CartesianIndex(2, 2), ),
                 (-1:2, CartesianIndex(0):CartesianIndex(2)),
@@ -351,7 +351,7 @@ end
                 (IdOffsetRange(-1:2), 0:2),
         ]
 
-        for inds in [size.(one_based_axes[1], 1), one_based_axes...]
+        for inds in Any[size.(one_based_axes[1], 1), one_based_axes...]
             # test API
             a = OffsetMatrix{Float64}(undef, inds)
             ax = (IdOffsetRange(Base.OneTo(4), 0), IdOffsetRange(Base.OneTo(3), 0))
@@ -385,7 +385,7 @@ end
             a = OffsetMatrix{Missing}(missing, inds)
             @test axes(a) === ax
 
-            for (T, t) in [(Nothing, nothing), (Missing, missing)]
+            for (T, t) in Any[(Nothing, nothing), (Missing, missing)]
                 a = OffsetMatrix{Union{T, Vector{Int}}}(undef, inds)
                 @test !isassigned(a, -1, 0)
                 @test eltype(a) === Union{T, Vector{Int}}
@@ -421,7 +421,7 @@ end
         # nested offset array
         a = rand(4, 3)
         oa = OffsetArray(a, -1, -2)
-        for inds in [.-oa.offsets, one_based_axes...]
+        for inds in Any[.-oa.offsets, one_based_axes...]
             ooa = OffsetArray(oa, inds)
             @test ooa === OffsetArray(oa, inds...) === OffsetMatrix(oa, inds) === OffsetMatrix(oa, inds...)
             @test typeof(parent(ooa)) <: Matrix
@@ -496,13 +496,13 @@ end
         @testset "convenience constructors" begin
             ax = (2:3, 4:5)
 
-            for f in [zeros, ones]
+            for f in (zeros, ones)
                 a = f(Float64, ax)
                 @test axes(a) == ax
                 @test eltype(a) == Float64
             end
 
-            for f in [trues, falses]
+            for f in (trues, falses)
                 a = f(ax)
                 @test axes(a) == ax
                 @test eltype(a) == Bool
@@ -573,7 +573,7 @@ end
         end
         @testset "TupleOfRanges" begin
             Base.to_indices(A, inds, t::Tuple{TupleOfRanges{N}}) where {N} = t
-            OffsetArrays.AxisConversionStyle(::Type{TupleOfRanges{N}}) where {N} = 
+            OffsetArrays.AxisConversionStyle(::Type{TupleOfRanges{N}}) where {N} =
                 OffsetArrays.TupleOfRanges()
 
             Base.convert(::Type{Tuple{Vararg{AbstractUnitRange{Int}}}}, t::TupleOfRanges) = t.x
@@ -584,7 +584,7 @@ end
             @test axes(oa) == inds.x
         end
         @testset "NewColon" begin
-            Base.to_indices(A, inds, t::Tuple{NewColon,Vararg{Any}}) = 
+            Base.to_indices(A, inds, t::Tuple{NewColon,Vararg{Any}}) =
                 (_uncolon(inds, t), to_indices(A, Base.tail(inds), Base.tail(t))...)
 
             _uncolon(inds::Tuple{}, I::Tuple{NewColon, Vararg{Any}}) = OneTo(1)
@@ -598,7 +598,7 @@ end
 
     @testset "Offset range construction" begin
         r = -2:5
-        for AT in [OffsetArray, OffsetVector]
+        for AT in Any[OffsetArray, OffsetVector]
             y = AT(r, r)
             @test axes(y) == (r,)
             @test step(y) == step(r)
@@ -1236,8 +1236,8 @@ end
     @test sort(A, dims = 1) == OffsetArray(sort(parent(A), dims = 1), A.offsets)
     @test sort(A, dims = 2) == OffsetArray(sort(parent(A), dims = 2), A.offsets)
 
-    @test mapslices(v->sort(v), A, dims = 1) == OffsetArray(mapslices(v->sort(v), parent(A), dims = 1), A.offsets)
-    @test mapslices(v->sort(v), A, dims = 2) == OffsetArray(mapslices(v->sort(v), parent(A), dims = 2), A.offsets)
+    @test mapslices(sort, A, dims = 1) == OffsetArray(mapslices(sort, parent(A), dims = 1), A.offsets)
+    @test mapslices(sort, A, dims = 2) == OffsetArray(mapslices(sort, parent(A), dims = 2), A.offsets)
 end
 
 @testset "rot/reverse" begin


### PR DESCRIPTION
I was basically using this package to test out some new (not-yet-released) stuff in SnoopCompile. This has little real-world impact: it shaves about 1.2s off the time to run the tests, which no one will complain about, but the package overall was already in pretty good shape.

Perhaps the most important aspect of this is that it bumps the [compat] on Adapt, and closes #174.

This is easier to review if you suppress whitespace changes. @jishnub, is your editor set to trim trailing whitespace automatically? If not, I personally like having that turned on.