### PR TITLE
Make no_offset_view inferrable

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -436,6 +436,7 @@ julia> A
 """
 no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
 no_offset_view(a::AbstractUnitRange) = UnitRange(a)
+no_offset_view(a::Base.Slice) = Base.Slice(UnitRange(a))
 no_offset_view(a::Array) = a
 no_offset_view(i::Number) = i
 no_offset_view(A::AbstractArray) = _no_offset_view(axes(A), A)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -435,11 +435,15 @@ julia> A
 ```
 """
 no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
+no_offset_view(a::AbstractUnitRange) = UnitRange(a)
 no_offset_view(a::Array) = a
+no_offset_view(i::Number) = i
 no_offset_view(A::AbstractArray) = _no_offset_view(axes(A), A)
 _no_offset_view(::Tuple{}, A::AbstractArray{T,0}) where T = A
 _no_offset_view(::Tuple{<:Base.OneTo,Vararg{<:Base.OneTo}}, A::AbstractArray) = A
 _no_offset_view(::Any, A::AbstractArray) = OffsetArray(A, Origin(1))
+
+no_offset_view(S::SubArray) = view(parent(S), map(no_offset_view, parentindices(S))...)
 
 ####
 # work around for segfault in searchsorted*

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -437,7 +437,8 @@ julia> A
 no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
 no_offset_view(a::AbstractUnitRange) = UnitRange(a)
 if isdefined(Base, :IdentityUnitRange)
-    no_offset_view(a::Base.Slice) = Base.Slice(UnitRange(a))
+    no_offset_view(a::Base.Slice) = Base.Slice(UnitRange(a))  # valid only if Slice is distinguished from IdentityUnitRange
+    no_offset_view(S::SubArray) = view(parent(S), map(no_offset_view, parentindices(S))...)
 end
 no_offset_view(a::Array) = a
 no_offset_view(i::Number) = i
@@ -445,8 +446,6 @@ no_offset_view(A::AbstractArray) = _no_offset_view(axes(A), A)
 _no_offset_view(::Tuple{}, A::AbstractArray{T,0}) where T = A
 _no_offset_view(::Tuple{<:Base.OneTo,Vararg{<:Base.OneTo}}, A::AbstractArray) = A
 _no_offset_view(::Any, A::AbstractArray) = OffsetArray(A, Origin(1))
-
-no_offset_view(S::SubArray) = view(parent(S), map(no_offset_view, parentindices(S))...)
 
 ####
 # work around for segfault in searchsorted*

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -434,9 +434,12 @@ julia> A
   2  4  6
 ```
 """
-no_offset_view(A::AbstractArray) = OffsetArray(A, Origin(1))
 no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
 no_offset_view(a::Array) = a
+no_offset_view(A::AbstractArray) = _no_offset_view(axes(A), A)
+_no_offset_view(::Tuple{}, A::AbstractArray{T,0}) where T = A
+_no_offset_view(::Tuple{<:Base.OneTo,Vararg{<:Base.OneTo}}, A::AbstractArray) = A
+_no_offset_view(::Any, A::AbstractArray) = OffsetArray(A, Origin(1))
 
 ####
 # work around for segfault in searchsorted*

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -434,14 +434,7 @@ julia> A
   2  4  6
 ```
 """
-function no_offset_view(A::AbstractArray)
-    if Base.has_offset_axes(A)
-        OffsetArray(A, Origin(1))
-    else
-        A
-    end
-end
-
+no_offset_view(A::AbstractArray) = OffsetArray(A, Origin(1))
 no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
 no_offset_view(a::Array) = a
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -436,7 +436,9 @@ julia> A
 """
 no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
 no_offset_view(a::AbstractUnitRange) = UnitRange(a)
-no_offset_view(a::Base.Slice) = Base.Slice(UnitRange(a))
+if isdefined(Base, :IdentityUnitRange)
+    no_offset_view(a::Base.Slice) = Base.Slice(UnitRange(a))
+end
 no_offset_view(a::Array) = a
 no_offset_view(i::Number) = i
 no_offset_view(A::AbstractArray) = _no_offset_view(axes(A), A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1403,6 +1403,7 @@ end
 Base.parent(x::PointlessWrapper) = x.parent
 Base.size(x::PointlessWrapper) = size(parent(x))
 Base.axes(x::PointlessWrapper) = axes(parent(x))
+Base.getindex(x::PointlessWrapper, i...) = x.parent[i...]
 
 @testset "no offset view" begin
     # OffsetArray fallback
@@ -1415,7 +1416,7 @@ Base.axes(x::PointlessWrapper) = axes(parent(x))
     @inferred no_offset_view(O2)
 
     P = PointlessWrapper(A)
-    @test no_offset_view(P) ≡ P
+    @test @inferred(no_offset_view(P)) == P
 
     # generic fallback
     A = collect(reshape(1:12, 3, 4))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1465,10 +1465,7 @@ Base.getindex(x::PointlessWrapper, i...) = x.parent[i...]
     @test V != collect(V)
     @test OffsetArrays.no_offset_view(V) == collect(V)
     V = @view O[:,:]
-    if isdefined(Base, :IdentityUnitRange)
-        # If `Slice` is distinguished from `IdentityUnitRange`
-        @test IndexStyle(A) == IndexStyle(O) == IndexStyle(V) == IndexStyle(OffsetArrays.no_offset_view(V)) == IndexLinear()
-    end
+    @test IndexStyle(A) == IndexStyle(O) == IndexStyle(V) == IndexStyle(OffsetArrays.no_offset_view(V)) == IndexLinear()
 end
 
 @testset "no nesting" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1416,7 +1416,10 @@ Base.getindex(x::PointlessWrapper, i...) = x.parent[i...]
     @inferred no_offset_view(O2)
 
     P = PointlessWrapper(A)
-    @test @inferred(no_offset_view(P)) == P
+    @test @inferred(no_offset_view(P)) === P
+    @test @inferred(no_offset_view(A)) === A
+    a0 = reshape([1])
+    @test @inferred(no_offset_view(a0)) === a0
 
     # generic fallback
     A = collect(reshape(1:12, 3, 4))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,7 @@ end
 end
 
 @testset "IdOffsetRange" begin
-    
+
     function check_indexed_by(r, rindx)
         for i in rindx
             r[i]
@@ -1522,6 +1522,7 @@ end
 @testset "Adapt" begin
     # We need another storage type, CUDA.jl defines one but we can't use that for CI
     # let's define an appropriate method for SArrays
+    Adapt.adapt_storage(::Type{SA}, xs::Array) where SA<:SArray         = convert(SA, xs)   # ambiguity
     Adapt.adapt_storage(::Type{SA}, xs::AbstractArray) where SA<:SArray = convert(SA, xs)
     arr = OffsetArray(rand(3, 3), -1:1, -1:1)
     s_arr = adapt(SMatrix{3,3}, arr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1420,6 +1420,8 @@ Base.getindex(x::PointlessWrapper, i...) = x.parent[i...]
     @test @inferred(no_offset_view(A)) === A
     a0 = reshape([1])
     @test @inferred(no_offset_view(a0)) === a0
+    a0v = view(a0)
+    @test @inferred(no_offset_view(a0v)) === a0v
 
     # generic fallback
     A = collect(reshape(1:12, 3, 4))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1460,6 +1460,8 @@ Base.getindex(x::PointlessWrapper, i...) = x.parent[i...]
     V = view(O, r1, r2)
     @test V != collect(V)
     @test OffsetArrays.no_offset_view(V) == collect(V)
+    V = @view O[:,:]
+    @test IndexStyle(A) == IndexStyle(O) == IndexStyle(V) == IndexStyle(OffsetArrays.no_offset_view(V)) == IndexLinear()
 end
 
 @testset "no nesting" begin


### PR DESCRIPTION
This changes the implementation so that the axis *value*s
do not affect the type of the output.

Technically this is a breaking change, but only at the level
of the returned types, not at the level of returned values.