### PR TITLE
Type assertions in converting offsets to Ints

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -118,7 +118,7 @@ struct OffsetArray{T,N,AA<:AbstractArray{T,N}} <: AbstractArray{T,N}
 end
 
 function OffsetArray{T, N, AA}(parent::AA, offsets::NTuple{N, <:Integer}) where {T, N, AA<:AbstractArray{T,N}}
-    OffsetArray{T, N, AA}(parent, map(x -> convert(Int, x), offsets))
+    OffsetArray{T, N, AA}(parent, map(x -> convert(Int, x)::Int, offsets))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,6 +185,13 @@ end
     @test first(rred) == first(r)
 end
 
+# used in testing the constructor
+struct WeirdInteger{T} <: Integer
+    x :: T
+end
+# assume that it doesn't behave as expected
+Base.convert(::Type{Int}, a::WeirdInteger) = a
+
 @testset "Constructors" begin
     @testset "Single-entry arrays in dims 0:5" begin
         for n = 0:5
@@ -535,6 +542,9 @@ end
         @test_throws TypeError OffsetArray{Float64,2,Matrix{ComplexF64}}
         # ndim of an OffsetArray should match that of the parent
         @test_throws TypeError OffsetArray{Float64,3,Matrix{Float64}}
+
+        # should throw a TypeError if the offsets can not be converted to Ints
+        @test_throws TypeError OffsetVector{Int,Vector{Int}}(zeros(Int,2), (WeirdInteger(1),))
     end
 
     @testset "custom range types" begin


### PR DESCRIPTION
The inner `OffsetArray` constructor requires the offsets to be `Int`s, and #188 allowed other `Integer` types to be converted to `Int`s. This PR adds a type assertion in the outer constructor to avoid a stack overflow if the conversion doesn't work as expected.