### PR TITLE
Display IdOffsetRange fields

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -100,7 +100,7 @@ The coefficients of this polynomial are a naturally `-1` based list, since the `
 (counting from `-1`) `6, 5, -2, 3, 1` is the coefficient corresponding to the `n`th power of `x`. This Laurent polynomial can be evaluated at say `x = 2` as follows.
 
 ```jldoctest; setup = :(using OffsetArrays)
-julia> coeffs = OffsetVector([6, 5, -2, 3, 1], -1:3)
+julia> coeffs = OffsetVector(Int64[6, 5, -2, 3, 1], -1:3)
 5-element OffsetArray(::Vector{Int64}, -1:3) with eltype Int64 with indices -1:3:
   6
   5

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -1,5 +1,5 @@
 """
-    ro = IdOffsetRange(r::AbstractUnitRange, offset=0)
+    ro = IdOffsetRange(r::AbstractUnitRange, offset = 0)
 
 Construct an "identity offset range". Numerically, `collect(ro) == collect(r) .+ offset`,
 with the additional property that `axes(ro, 1) = axes(r, 1) .+ offset`.
@@ -11,10 +11,13 @@ i.e., it's the "identity," which is the origin of the "Id" in `IdOffsetRange`.
 The most common case is shifting a range that starts at 1 (either `1:n` or `Base.OneTo(n)`):
 ```jldoctest; setup=:(import OffsetArrays)
 julia> ro = OffsetArrays.IdOffsetRange(1:3, -2)
-OffsetArrays.IdOffsetRange(-1:1)
+OffsetArrays.IdOffsetRange(1:3, -2)
 
 julia> axes(ro, 1)
-OffsetArrays.IdOffsetRange(-1:1)
+OffsetArrays.IdOffsetRange(1:3, -2)
+
+julia> axes(ro, 1) == -1:1
+true
 
 julia> ro[-1]
 -1
@@ -26,10 +29,10 @@ ERROR: BoundsError: attempt to access 3-element UnitRange{$Int} at index [5]
 If the range doesn't start at 1, the values may be different from the indices:
 ```jldoctest; setup=:(import OffsetArrays)
 julia> ro = OffsetArrays.IdOffsetRange(11:13, -2)
-OffsetArrays.IdOffsetRange(9:11)
+OffsetArrays.IdOffsetRange(11:13, -2)
 
 julia> axes(ro, 1)     # 11:13 is indexed by 1:3, and the offset is also applied to the axes
-OffsetArrays.IdOffsetRange(-1:1)
+OffsetArrays.IdOffsetRange(1:3, -2)
 
 julia> ro[-1]
 9
@@ -174,7 +177,7 @@ Broadcast.broadcasted(::Base.Broadcast.DefaultArrayStyle{1}, ::typeof(+), r::IdO
 Broadcast.broadcasted(::Base.Broadcast.DefaultArrayStyle{1}, ::typeof(+), x::Integer, r::IdOffsetRange{T}) where T =
     IdOffsetRange{T}(x .+ r.parent, r.offset)
 
-Base.show(io::IO, r::IdOffsetRange) = print(io, "OffsetArrays.IdOffsetRange(",first(r), ':', last(r),")")
+Base.show(io::IO, r::IdOffsetRange) = print(io, "OffsetArrays.IdOffsetRange(",UnitRange(r.parent), ", ", r.offset,")")
 
 # Optimizations
 @inline Base.checkindex(::Type{Bool}, inds::IdOffsetRange, i::Real) = Base.checkindex(Bool, inds.parent, i - inds.offset)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -977,9 +977,9 @@ end
     a = OffsetArray([1 2; 3 4], -1:0, 5:6)
     io = IOBuffer()
     show(io, axes(a, 1))
-    @test String(take!(io)) == "OffsetArrays.IdOffsetRange(-1:0)"
+    @test String(take!(io)) == "OffsetArrays.IdOffsetRange(1:2, -2)"
     show(io, axes(a, 2))
-    @test String(take!(io)) == "OffsetArrays.IdOffsetRange(5:6)"
+    @test String(take!(io)) == "OffsetArrays.IdOffsetRange(1:2, 4)"
 
     @test Base.inds2string(axes(a)) == Base.inds2string(map(UnitRange, axes(a)))
 


### PR DESCRIPTION
While #179 is still undecided, this is a stop-gap (and hopefully less disputed) solution. In my experience displaying the axes of an `OffsetArray` is necessary more in debugging than anything else, and having the offsets printed makes life easier. This makes interpreting the axis span a little trickier, but it's possible to get used to this.

After this PR:
```julia
julia> a = zeros(3:4, 3:4);

julia> axes(a, 1)
OffsetArrays.IdOffsetRange(1:2, 2)
```

It's always possible to convert these to `UnitRange`s wherever necessary: 
```julia
julia> UnitRange.(axes(a))
(3:4, 3:4)
```