### PR TITLE
Correct bounds checking for AbstractVectors with no indices specified (fixes #194)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.5.1"
+version = "1.5.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -179,6 +179,16 @@ Base.show(io::IO, r::IdOffsetRange) = print(io, "OffsetArrays.IdOffsetRange(",fi
 # Optimizations
 @inline Base.checkindex(::Type{Bool}, inds::IdOffsetRange, i::Real) = Base.checkindex(Bool, inds.parent, i - inds.offset)
 
+# issue 194
+# The indexing operation A[] gets mapped to A[1]. 
+# The bounds-checking for this needs to be handled separately for AbstractVectors
+# See https://github.com/JuliaLang/julia/issues/39379 for this issue reported in Base
+# Once a PR fixing it is merged, we may limit our fix to earlier Julia versions
+@inline function Base.checkbounds_indices(::Type{Bool}, IA::Tuple{IdOffsetRange}, ::Tuple{})
+    x = IA[1]
+    length(x) == 1 && first(x) == one(eltype(x))
+end
+
 if VERSION < v"1.5.2"
     # issue 100, 133: IdOffsetRange as another index-preserving case shouldn't comtribute offsets
     # fixed by https://github.com/JuliaLang/julia/pull/37204

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -711,6 +711,22 @@ end
         @test setindex!(A, 2, 4) === A
         @test A[4] == 2
     end
+
+    @testset "issue 194" begin
+        A = OffsetArray([0], 1);
+        @test Base.checkbounds_indices(Bool, axes(A), ()) == false
+        @test_throws BoundsError A[]
+        A = OffsetArray([6], 1:1)
+        @test A[] == 6
+
+        A = OffsetArray(reshape(1:4, 2, 2), 2, 2);
+        @test Base.checkbounds_indices(Bool, axes(A), ()) == false
+        @test_throws BoundsError A[]
+        A = OffsetArray(reshape([6], 1, 1), 1:1, 1:1);
+        @test A[] == 6
+        A = OffsetArray(A, 1:1, 2:2);
+        @test A[] == 6
+    end
 end
 
 @testset "Vector indexing" begin


### PR DESCRIPTION
After this PR

```julia
julia> OffsetArray([0], 1)[]
ERROR: BoundsError: attempt to access 1-element OffsetArray(::Array{Int64,1}, 2:2) with eltype Int64 with indices 2:2 at index []

julia> OffsetArray([6], 1:1)[]
6
```