### PR TITLE
use the first linear index instead of 1 for zero-argument getindex (redo #195)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.5.2"
+version = "1.5.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.5.3"
+version = "1.5.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -507,10 +507,9 @@ if VERSION < v"1.1.0-DEV.783"
     Base.copyfirst!(dest::OffsetArray, src::OffsetArray) = (maximum!(parent(dest), parent(src)); return dest)
 end
 
-# TODO: modify this when https://github.com/JuliaLang/julia/pull/39393 get merged
-if VERSION <= v"1.7.0-DEV.375"
-    # issue 194
-    # index for zero-argument getindex should be first linear index instead of 1
+if VERSION <= v"1.7.0-DEV.400"
+    # https://github.com/JuliaLang/julia/pull/39393
+    # index for zero-argument getindex should be first linear index instead of 1 (#194)
     Base._to_linear_index(A::OffsetArray) = first(LinearIndices(A))
 end
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -507,6 +507,13 @@ if VERSION < v"1.1.0-DEV.783"
     Base.copyfirst!(dest::OffsetArray, src::OffsetArray) = (maximum!(parent(dest), parent(src)); return dest)
 end
 
+# TODO: modify this when https://github.com/JuliaLang/julia/pull/39393 get merged
+if VERSION <= v"1.7.0-DEV.375"
+    # issue 194
+    # index for zero-argument getindex should be first linear index instead of 1
+    Base._to_linear_index(A::OffsetArray) = first(LinearIndices(A))
+end
+
 ##
 # Adapt allows for automatic conversion of CPU OffsetArrays to GPU OffsetArrays
 ##

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -179,16 +179,6 @@ Base.show(io::IO, r::IdOffsetRange) = print(io, "OffsetArrays.IdOffsetRange(",fi
 # Optimizations
 @inline Base.checkindex(::Type{Bool}, inds::IdOffsetRange, i::Real) = Base.checkindex(Bool, inds.parent, i - inds.offset)
 
-# issue 194
-# The indexing operation A[] gets mapped to A[1]. 
-# The bounds-checking for this needs to be handled separately for AbstractVectors
-# See https://github.com/JuliaLang/julia/issues/39379 for this issue reported in Base
-# Once a PR fixing it is merged, we may limit our fix to earlier Julia versions
-@inline function Base.checkbounds_indices(::Type{Bool}, IA::Tuple{IdOffsetRange}, ::Tuple{})
-    x = IA[1]
-    length(x) == 1 && first(x) == one(eltype(x))
-end
-
 if VERSION < v"1.5.2"
     # issue 100, 133: IdOffsetRange as another index-preserving case shouldn't comtribute offsets
     # fixed by https://github.com/JuliaLang/julia/pull/37204

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -712,20 +712,13 @@ end
         @test A[4] == 2
     end
 
-    @testset "issue 194" begin
-        A = OffsetArray([0], 1);
-        @test Base.checkbounds_indices(Bool, axes(A), ()) == false
-        @test_throws BoundsError A[]
-        A = OffsetArray([6], 1:1)
-        @test A[] == 6
-
-        A = OffsetArray(reshape(1:4, 2, 2), 2, 2);
-        @test Base.checkbounds_indices(Bool, axes(A), ()) == false
-        @test_throws BoundsError A[]
-        A = OffsetArray(reshape([6], 1, 1), 1:1, 1:1);
-        @test A[] == 6
-        A = OffsetArray(A, 1:1, 2:2);
-        @test A[] == 6
+    @testset "Zero-index indexing (#194)" begin
+        @test OffsetArray([6], 2:2)[] == 6
+        @test OffsetArray(fill(6, 1, 1), 2:2, 3:3)[] == 6
+        @test OffsetArray(fill(6))[] == 6
+        @test_throws BoundsError OffsetArray([6,7], 2:3)[]
+        @test_throws BoundsError OffsetArray([6 7], 2:2, 2:3)[]
+        @test_throws BoundsError OffsetArray([], 2:1)[]
     end
 end
 


### PR DESCRIPTION
> https://github.com/JuliaLang/julia/issues/39379#issuecomment-767045715
>
> > Here's the root problem:
> > 
> > https://github.com/JuliaLang/julia/blob/69d24532980bda6db510b6d4b71f66e7ffff2e81/base/abstractarray.jl#L1196
> > 
> > Edit: This should probably be `first(eachindex(A))` or somesuch.

Changes:

```julia
# master
OffsetArray([6], 2:2)[] # BoundsError
# this PR
OffsetArray([6], 2:2)[] == 6
```

Forked from https://github.com/JuliaLang/julia/pull/39393, I'll wait until that gets merged.

Technically this is a breaking change, but since v1.5.2 was released yesterday, I'd see this as a bug fix and bump a patch version for it.

cc: @jishnub @mbauman 