### PR TITLE
Fix indexing for 0D views

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -236,6 +236,14 @@ Base.eachindex(::IndexLinear, A::OffsetVector)   = axes(A, 1)
 @inline Base.axes(A::OffsetArray, d) = d <= ndims(A) ? IdOffsetRange(axes(parent(A), d), A.offsets[d]) : IdOffsetRange(axes(parent(A), d))
 @inline Base.axes1(A::OffsetArray{T,0}) where {T} = IdOffsetRange(axes(parent(A), 1))  # we only need to specialize this one
 
+# Issue 128
+# See https://github.com/JuliaLang/julia/issues/37274 for the issue reported in Base
+# We might not need this if the issue in Base is fixed, at that point we may impose an upper bound
+@inline function Base.compute_linindex(A::OffsetVector, I::NTuple{N,Any}) where N
+    IP = Base.fill_to_length(axes(A), Base.OneTo(1), Val(N))
+    Base.compute_linindex(first(LinearIndices(A)), 1, IP, I)
+end
+
 Base.similar(A::OffsetArray, ::Type{T}, dims::Dims) where T =
     similar(parent(A), T, dims)
 function Base.similar(A::AbstractArray, ::Type{T}, inds::Tuple{OffsetAxisKnownLength,Vararg{OffsetAxisKnownLength}}) where T

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -238,10 +238,13 @@ Base.eachindex(::IndexLinear, A::OffsetVector)   = axes(A, 1)
 
 # Issue 128
 # See https://github.com/JuliaLang/julia/issues/37274 for the issue reported in Base
-# We might not need this if the issue in Base is fixed, at that point we may impose an upper bound
-@inline function Base.compute_linindex(A::OffsetVector, I::NTuple{N,Any}) where N
-    IP = Base.fill_to_length(axes(A), Base.OneTo(1), Val(N))
-    Base.compute_linindex(first(LinearIndices(A)), 1, IP, I)
+# The fix https://github.com/JuliaLang/julia/pull/39404 should be available on v1.6
+# The following method is added on older Julia versions to ensure correct behavior for OffsetVectors
+if VERSION < v"1.6"
+    @inline function Base.compute_linindex(A::OffsetVector, I::NTuple{N,Any}) where N
+        IP = Base.fill_to_length(axes(A), Base.OneTo(1), Val(N))
+        Base.compute_linindex(first(LinearIndices(A)), 1, IP, I)
+    end
 end
 
 Base.similar(A::OffsetArray, ::Type{T}, dims::Dims) where T =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -943,6 +943,11 @@ end
     d = OffsetArray(c, 1:2)
     @test same_value(d, c)
     @test axes(d,1) == 1:2
+
+    # Issue 128
+    a = OffsetArray(1:3, 0:2);
+    b = @view a[0]
+    @test b[] == b[1] == 1
 end
 
 @testset "iteration" begin


### PR DESCRIPTION
This fixes #128 going by the discussion in [julia#37274](https://github.com/JuliaLang/julia/issues/37274#issuecomment-683497635) and in the spirit of #196.

Now 

```julia
julia> a = OffsetArray(1:3, 0:2);

julia> b = @view a[0];

julia> b[]
1

julia> b[1]
1

```