### PR TITLE
remove _unwrap

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -71,6 +71,3 @@ function _checkindices(N::Integer, indices, label)
     throw_argumenterror(N, indices, label) = throw(ArgumentError(label*" $indices are not compatible with a $(N)D array"))
     N == length(indices) || throw_argumenterror(N, indices, label)
 end
-
-_unwrap(r::IdOffsetRange) = r.parent .+ r.offset
-_unwrap(r::IdentityUnitRange) = r.indices

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1446,6 +1446,9 @@ Base.getindex(x::PointlessWrapper, i...) = x.parent[i...]
     @test axes(noffax, 1) == 1:10   # ideally covered by the above, but current it isn't
     @test isa(noffax, AbstractUnitRange)
 
+    r = Base.OneTo(4)
+    @test OffsetArrays.no_offset_view(r) isa typeof(r)
+
     # SubArrays
     A = reshape(1:12, 3, 4)
     V = view(A, OffsetArrays.IdentityUnitRange(2:3), OffsetArrays.IdentityUnitRange(2:3))


### PR DESCRIPTION
This util method is not necessary anymore, as `no_offset_view` is equivalent to it. This also adds a methods to `_no_offset_view` to ignore `AbstractUnitRanges` with `Base.OneTo` axes and not convert these to `UnitRanges`. This means types such as `Base.OneTo` will be preserved.

```julia
julia> OffsetArrays.no_offset_view(Base.OneTo(4)) |> typeof
Base.OneTo{Int64}
```