### PR TITLE
optimize reductions for OffsetRanges

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -327,7 +327,6 @@ end
     A
 end
 
-Base.copy(a::OffsetArray) = OffsetArray(copy(parent(a)), a.offsets)
 Base.in(x, A::OffsetArray) = in(x, parent(A))
 
 Base.strides(A::OffsetArray) = strides(parent(A))

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -377,7 +377,7 @@ function Base.mapreduce(f, op, As::OffsetUnitRange...; kw...)
     mapreduce(f, op, AIds...; kw...)
 end
 
-# Optimize certain reductions that treat an OffsetVector as a list 
+# Optimize certain reductions that treat an OffsetVector as a list
 for f in [:minimum, :maximum, :extrema, :sum]
     @eval Base.$f(r::OffsetRange) = $f(parent(r))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1297,31 +1297,36 @@ end
     @test clamp.(A, (amax+amin)/2, amax) == OffsetArray(clamp.(parent(A), (amax+amin)/2, amax), axes(A))
 
     @testset "mapreduce for OffsetRange" begin
-        for r in [5:100, IdOffsetRange(1:100, 4), OffsetArrays.IdOffsetRange(4:5), # AbstractUnitRanges
+        for r in Any[5:100, IdOffsetRange(1:100, 4), IdOffsetRange(4:5), # AbstractUnitRanges
             2:4:14, 1.5:1.0:10.5, # AbstractRanges
             ]
+
             a = OffsetVector(r, 2);
             @test mapreduce(identity, +, a) == mapreduce(identity, +, r)
             @test mapreduce(x -> x^2, (x,y) -> x, a) == mapreduce(x -> x^2, (x,y) -> x, r)
 
             b = mapreduce(identity, +, a, dims = 1)
-            @test no_offset_view(b) == mapreduce(identity, +, r, dims = 1)
+            br = mapreduce(identity, +, r, dims = 1)
+            @test no_offset_view(b) == no_offset_view(br)
             @test axes(b, 1) == first(axes(a,1)):first(axes(a,1))
 
             @test mapreduce(identity, +, a, init = 3) == mapreduce(identity, +, r, init = 3)
             if VERSION >= v"1.2"
+                @test mapreduce((x,y) -> x*y, +, a, a) == mapreduce((x,y) -> x*y, +, r, r)
                 @test mapreduce((x,y) -> x*y, +, a, a, init = 10) == mapreduce((x,y) -> x*y, +, r, r, init = 10)
             end
 
             for f in [sum, minimum, maximum]
                 @test f(a) == f(r)
-                
+
                 b = f(a, dims = 1);
-                @test no_offset_view(b) == f(r, dims = 1)
+                br = f(r, dims = 1)
+                @test no_offset_view(b) == no_offset_view(br)
                 @test axes(b, 1) == first(axes(a,1)):first(axes(a,1))
 
                 b = f(a, dims = 2);
-                @test no_offset_view(b) == f(r, dims = 2)
+                br = f(r, dims = 2)
+                @test no_offset_view(b) == no_offset_view(br)
                 @test axes(b, 1) == axes(a,1)
             end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1297,7 +1297,9 @@ end
     @test clamp.(A, (amax+amin)/2, amax) == OffsetArray(clamp.(parent(A), (amax+amin)/2, amax), axes(A))
 
     @testset "mapreduce for OffsetRange" begin
-        for r in [5:100, IdOffsetRange(1:100, 4), OffsetArrays.IdOffsetRange(4:5), ]
+        for r in [5:100, IdOffsetRange(1:100, 4), OffsetArrays.IdOffsetRange(4:5), # AbstractUnitRanges
+            2:4:14, 1.5:1.0:10.5, # AbstractRanges
+            ]
             a = OffsetVector(r, 2);
             @test mapreduce(identity, +, a) == mapreduce(identity, +, r)
             @test mapreduce(x -> x^2, (x,y) -> x, a) == mapreduce(x -> x^2, (x,y) -> x, r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -324,6 +324,13 @@ Base.convert(::Type{Int}, a::WeirdInteger) = a
         @test_throws OverflowError OffsetArray{Float64, 1, typeof(ao)}(ao, (-2, )) # inner Constructor
         @test_throws OverflowError OffsetArray(ao, (-2, )) # convinient constructor accumulate offsets
 
+        @testset "OffsetRange" begin
+            local r = 1:100
+            local a = OffsetVector(r, 4)
+            @test first(r) in a
+            @test !(last(r) + 1 in a)
+        end
+
         # disallow OffsetVector(::Array{<:Any, N}, offsets) where N != 1
         @test_throws ArgumentError OffsetVector(zeros(2,2), (2, 2))
         @test_throws ArgumentError OffsetVector(zeros(2,2), 2, 2)
@@ -1288,6 +1295,37 @@ end
 
     amin, amax = extrema(parent(A))
     @test clamp.(A, (amax+amin)/2, amax) == OffsetArray(clamp.(parent(A), (amax+amin)/2, amax), axes(A))
+
+    @testset "mapreduce for OffsetRange" begin
+        for r in [5:100, IdOffsetRange(1:100, 4), OffsetArrays.IdOffsetRange(4:5), ]
+            a = OffsetVector(r, 2);
+            @test mapreduce(identity, +, a) == mapreduce(identity, +, r)
+            @test mapreduce(x -> x^2, (x,y) -> x, a) == mapreduce(x -> x^2, (x,y) -> x, r)
+
+            b = mapreduce(identity, +, a, dims = 1)
+            @test no_offset_view(b) == mapreduce(identity, +, r, dims = 1)
+            @test axes(b, 1) == first(axes(a,1)):first(axes(a,1))
+
+            @test mapreduce(identity, +, a, init = 3) == mapreduce(identity, +, r, init = 3)
+            if VERSION >= v"1.2"
+                @test mapreduce((x,y) -> x*y, +, a, a, init = 10) == mapreduce((x,y) -> x*y, +, r, r, init = 10)
+            end
+
+            for f in [sum, minimum, maximum]
+                @test f(a) == f(r)
+                
+                b = f(a, dims = 1);
+                @test no_offset_view(b) == f(r, dims = 1)
+                @test axes(b, 1) == first(axes(a,1)):first(axes(a,1))
+
+                b = f(a, dims = 2);
+                @test no_offset_view(b) == f(r, dims = 2)
+                @test axes(b, 1) == axes(a,1)
+            end
+
+            @test extrema(a) == extrema(r)
+        end
+    end
 end
 
 # v  = OffsetArray([1,1e100,1,-1e100], (-3,))*1000


### PR DESCRIPTION
Fixes #201 partly

Now `mapreduce` operations involving `OffsetUnitRange`s convert the arguments to `IdOffsetRange`s

```julia
julia> @btime sum(a) setup = (a = OffsetVector(1:rand(10000:10000),3));
  4.260 ns (0 allocations: 0 bytes)

julia> @btime sum(a, dims = 1) setup = (a = OffsetVector(1:rand(10000:10000),3));
  85.122 ns (1 allocation: 96 bytes)
```

This does not optimize reductions for `OffsetRange`s in general, as there's no `IdOffsetRange` equivalent currently for non-`AbstractUnitRange`s that preserves the axes.