### PR TITLE
Fix show for OffsetRanges (redo #200)

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -367,7 +367,7 @@ indexing is faster with ranges =#
 @propagate_inbounds Base.getindex(r::UnitRange{<:Integer}, s::IIUR) = IdentityUnitRange(r[no_offset_view(s)])
 
 function Base.show(io::IO, r::OffsetRange)
-    show(io, UnitRange(r.parent))
+    show(io, r.parent)
     print(io, " with indices ", UnitRange(axes(r, 1)))
 end
 Base.show(io::IO, ::MIME"text/plain", r::OffsetRange) = show(io, r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1004,10 +1004,11 @@ end
     @test String(take!(io)) == "3:5 with indices 0:2"
 
     # issue #198
-    r = axes(OffsetVector(1:10, -5), 1)
-    a = OffsetVector(r, 5)
-    show(io, a)
-    @test String(take!(io)) == "$(UnitRange(r)) with indices $(UnitRange(axes(a,1)))"
+    for r in [axes(OffsetVector(1:10, -5), 1), 1:1:2, 1.0:1.0:2.0, 1:-1:-5]
+        a = OffsetVector(r, 5)
+        show(io, a)
+        @test String(take!(io)) == "$r with indices $(UnitRange(axes(a,1)))"
+    end
 
     d = Diagonal([1,2,3])
     Base.print_array(io, d)


### PR DESCRIPTION
Unfortunately my attempt at not displaying the parent types while printing OffsetRanges in #200 was buggy, and was not caught because of insufficient tests. This PR reverts that, so now the parent types will be printed as it used to be before #200. There might be a better solution using `no_offset_view`, but it's better to be conservative.

After this:
```julia
julia> r = OffsetVector(Base.IdentityUnitRange(-3:4), 2)
Base.IdentityUnitRange(-3:4) with indices -1:6
```