### PR TITLE
Fix indexing with OffsetRanges

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -369,7 +369,8 @@ for OR in [:IIUR, :IdOffsetRange]
     end
 end
 
-Base.getindex(a::OffsetRange, ::Colon) = OffsetArray(a.parent[:], a.offsets)
+# This is technically breaking, so it might be incorporated in the next major release
+# Base.getindex(a::OffsetRange, ::Colon) = OffsetArray(a.parent[:], a.offsets)
 
 function Base.show(io::IO, r::OffsetRange)
     show(io, UnitRange(r.parent))

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -348,7 +348,7 @@ end
 @propagate_inbounds function Base.getindex(a::OffsetRange, r::IdOffsetRange)
     OffsetArray(a.parent[r.parent .+ (r.offset - a.offsets[1])], axes(r))
 end
-@propagate_inbounds Base.getindex(a::OffsetRange, r::AbstractRange) = _maybewrapOffsetArray(a.parent[r .- a.offsets[1]], axes(r))
+@propagate_inbounds Base.getindex(a::OffsetRange, r::AbstractRange) = _maybewrapaxes(a.parent[r .- a.offsets[1]], axes(r,1))
 @propagate_inbounds Base.getindex(a::AbstractRange, r::OffsetRange) = OffsetArray(a[parent(r)], axes(r))
 
 for OR in [:IIUR, :IdOffsetRange]

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -159,6 +159,10 @@ end
 @propagate_inbounds function Base.getindex(r::IdOffsetRange, s::AbstractUnitRange{<:Integer})
     return r.parent[s .- r.offset] .+ r.offset
 end
+# The following method is required to avoid falling back to getindex(::AbstractUnitRange, ::StepRange{<:Integer})
+@propagate_inbounds function Base.getindex(r::IdOffsetRange, s::StepRange{<:Integer})
+    return r.parent[s .- r.offset] .+ r.offset
+end
 @propagate_inbounds function Base.getindex(r::IdOffsetRange, s::IdentityUnitRange)
     return IdOffsetRange(r.parent[s .- r.offset], r.offset)
 end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -157,7 +157,10 @@ end
 
 @propagate_inbounds Base.getindex(r::IdOffsetRange, i::Integer) = r.parent[i - r.offset] + r.offset
 @propagate_inbounds function Base.getindex(r::IdOffsetRange, s::AbstractUnitRange{<:Integer})
-    return r.parent[s .- r.offset] .+ r.offset
+    offset_r = first(axes(r,1)) - 1
+    offset_s = first(axes(s,1)) - 1
+    pr = r.parent[s .- offset_r] .+ (offset_r - offset_s)
+    _maybewrapIdOffsetRange(UnitRange(pr), offset_s, axes(s,1))
 end
 # The following method is required to avoid falling back to getindex(::AbstractUnitRange, ::StepRange{<:Integer})
 @propagate_inbounds function Base.getindex(r::IdOffsetRange, s::StepRange{<:Integer})

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -157,20 +157,22 @@ end
 
 @propagate_inbounds Base.getindex(r::IdOffsetRange, i::Integer) = r.parent[i - r.offset] + r.offset
 @propagate_inbounds function Base.getindex(r::IdOffsetRange, s::AbstractUnitRange{<:Integer})
-    offset_r = first(axes(r,1)) - 1
     offset_s = first(axes(s,1)) - 1
-    pr = r.parent[s .- offset_r] .+ (offset_r - offset_s)
-    _maybewrapIdOffsetRange(UnitRange(pr), offset_s, axes(s,1))
+    pr = r.parent[s .- r.offset] .+ (r.offset - offset_s)
+    _maybewrapoffset(pr, offset_s, axes(s,1))
 end
 # The following method is required to avoid falling back to getindex(::AbstractUnitRange, ::StepRange{<:Integer})
 @propagate_inbounds function Base.getindex(r::IdOffsetRange, s::StepRange{<:Integer})
-    return r.parent[s .- r.offset] .+ r.offset
+    rs = r.parent[s .- r.offset] .+ r.offset
+    return no_offset_view(rs)
 end
+# The following two methods are not necessary as these are covered by the general case above, 
+# however these might be somewhat faster
 @propagate_inbounds function Base.getindex(r::IdOffsetRange, s::IdentityUnitRange)
-    return IdOffsetRange(r.parent[s .- r.offset], r.offset)
+    return _maybewrapoffset(r.parent[s .- r.offset], r.offset, axes(s,1))
 end
 @propagate_inbounds function Base.getindex(r::IdOffsetRange, s::IdOffsetRange)
-    return IdOffsetRange(r.parent[s.parent .+ (s.offset - r.offset)] .+ (r.offset - s.offset), s.offset)
+    return _maybewrapoffset(r.parent[s.parent .+ (s.offset - r.offset)] .+ (r.offset - s.offset), s.offset, axes(s,1))
 end
 
 # offset-preserve broadcasting

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -166,14 +166,6 @@ end
     rs = r.parent[s .- r.offset] .+ r.offset
     return no_offset_view(rs)
 end
-# The following two methods are not necessary as these are covered by the general case above, 
-# however these might be somewhat faster
-@propagate_inbounds function Base.getindex(r::IdOffsetRange, s::IdentityUnitRange)
-    return _maybewrapoffset(r.parent[s .- r.offset], r.offset, axes(s,1))
-end
-@propagate_inbounds function Base.getindex(r::IdOffsetRange, s::IdOffsetRange)
-    return _maybewrapoffset(r.parent[s.parent .+ (s.offset - r.offset)] .+ (r.offset - s.offset), s.offset, axes(s,1))
-end
 
 # offset-preserve broadcasting
 Broadcast.broadcasted(::Base.Broadcast.DefaultArrayStyle{1}, ::typeof(-), r::IdOffsetRange{T}, x::Integer) where T =

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -71,3 +71,6 @@ function _checkindices(N::Integer, indices, label)
     throw_argumenterror(N, indices, label) = throw(ArgumentError(label*" $indices are not compatible with a $(N)D array"))
     N == length(indices) || throw_argumenterror(N, indices, label)
 end
+
+_maybewrapOffsetArray(A, ax::Tuple{Base.OneTo, Vararg{Base.OneTo}}) = A
+_maybewrapOffsetArray(A, ax) = OffsetArray(A, ax)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,3 +74,6 @@ end
 
 _maybewrapOffsetArray(A, ax::Tuple{Base.OneTo, Vararg{Base.OneTo}}) = A
 _maybewrapOffsetArray(A, ax) = OffsetArray(A, ax)
+
+_maybewrapIdOffsetRange(r, of, ::Base.OneTo) = r
+_maybewrapIdOffsetRange(r, of, ::Any) = IdOffsetRange(r, of)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -72,8 +72,10 @@ function _checkindices(N::Integer, indices, label)
     N == length(indices) || throw_argumenterror(N, indices, label)
 end
 
-_maybewrapOffsetArray(A, ax::Tuple{Base.OneTo, Vararg{Base.OneTo}}) = A
-_maybewrapOffsetArray(A, ax) = OffsetArray(A, ax)
+_maybewrapaxes(A::AbstractVector, ::Base.OneTo) = no_offset_view(A)
+_maybewrapaxes(A::AbstractVector, ax) = OffsetArray(A, ax)
 
-_maybewrapIdOffsetRange(r, of, ::Base.OneTo) = r
-_maybewrapIdOffsetRange(r, of, ::Any) = IdOffsetRange(r, of)
+_maybewrapoffset(r::AbstractUnitRange, of, ::Base.OneTo) = no_offset_view(r)
+_maybewrapoffset(r::AbstractVector, of, ::Base.OneTo) = no_offset_view(r)
+_maybewrapoffset(r::AbstractUnitRange, of, ::Any) = IdOffsetRange(UnitRange(r), of)
+_maybewrapoffset(r::AbstractVector, of, axs) = OffsetArray(r .+ of, axs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -810,8 +810,8 @@ end
     @test A[:, :] == S[:, :] == A
 
     r1 = OffsetArray(IdentityUnitRange(100:1000), 3)
-    r2 = r1[:] # is equivalent to copy(r1)
-    @test r2 == r1 # this could be ===, but we choose a weaker test
+    r2 = r1[:]
+    @test r2 == r1
 
     for r1 in [
         # AbstractArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -744,6 +744,53 @@ end
     r1 = OffsetArray(IdentityUnitRange(100:1000), 3)
     r2 = r1[:] # is equivalent to copy(r1)
     @test r2 == r1 # this could be ===, but we choose a weaker test
+
+    for r1 in [1:1000, 1:3:1000, 1.0:3.0:1000.0, # 1-based index
+        OffsetArray(10:1000, 0), # 1-based index
+        OffsetArray(10:3:1000, 3), # offset index
+        OffsetArray(10.0:3:1000.0, 0), # 1-based index
+        OffsetArray(10.0:3:1000.0, 3), # offset index
+        OffsetArray(IdOffsetRange(10:1000, 1), -1), # 1-based index
+        OffsetArray(IdOffsetRange(10:1000, 1), 3), # offset index
+        OffsetArray(IdOffsetRange(IdOffsetRange(10:1000, -4), 1), 3), # 1-based index
+        OffsetArray(IdOffsetRange(IdOffsetRange(10:1000, -1), 1), 3), # offset index
+        ]
+
+        for r2 in [OffsetArray(5:80, 0), OffsetArray(5:2:80, 0), 
+            OffsetArray(IdentityUnitRange(5:80), -4), 
+            OffsetArray(IdOffsetRange(5:80), 0)]
+
+            r12 = r1[r2]
+            for i in eachindex(r2)
+                @test begin 
+                    res = r12[i] == r1[r2[i]]
+                    if !res
+                        @show r1 r2
+                    end
+                    res
+                end
+            end
+            @test first(r12) == r1[first(r2)]
+            @test last(r12) == r1[last(r2)]
+            @test axes(r12, 1) == axes(r2, 1)
+        end
+
+        for r2 in [5:80, 5:2:80, IdOffsetRange(5:80)]
+            r12 = r1[r2]
+            for i in eachindex(r2)
+                @test begin 
+                    res = r12[i] == r1[r2[i]]
+                    if !res
+                        @show r1 r2
+                    end
+                    res
+                end
+            end
+            @test first(r12) == r1[first(r2)]
+            @test last(r12) == r1[last(r2)]
+            @test axes(r12, 1) == axes(r2, 1)
+        end
+    end
 end
 
 # Useful for testing indexing
@@ -805,10 +852,17 @@ end
         @test a[ax[i]] == a[ax][i]
     end
 
-    for r1 in [OffsetArray(10:1000, 3), OffsetArray(10:3:1000, 3), 
-        OffsetArray(10.0:3:1000.0, 3), 
-        OffsetArray(IdOffsetRange(10:1000, 1), 3),
-        OffsetArray(IdOffsetRange(IdOffsetRange(10:1000, -4), 1), 3)]
+    for r1 in [OffsetArray(10:1000, 0), # 1-based index
+        OffsetArray(10:1000, 3), # offset index
+        OffsetArray(10:3:1000, 0), # 1-based index
+        OffsetArray(10:3:1000, 3), # offset index
+        OffsetArray(10.0:3:1000.0, 0), # 1-based index
+        OffsetArray(10.0:3:1000.0, 3), # offset index
+        OffsetArray(IdOffsetRange(10:1000, -3), 3), # 1-based index
+        OffsetArray(IdOffsetRange(10:1000, 1), 3), # offset index
+        OffsetArray(IdOffsetRange(IdOffsetRange(10:1000, -4), 1), 3), # 1-based index
+        OffsetArray(IdOffsetRange(IdOffsetRange(10:1000, -1), 1), 3), # offset index
+        ]
 
         for r2 in [OffsetArray(5:80, 40), OffsetArray(5:2:80, 40), 
             OffsetArray(IdentityUnitRange(5:80), 2), 


### PR DESCRIPTION
1. Indexing with `OffsetRange`s on master currently assumes that the parent has 1-based indexing. This PR generalizes this by removing this assumption.

On master:
```julia
julia> r1 = OffsetArray(IdOffsetRange(10:1000, 1), 3)
OffsetArrays.IdOffsetRange(11:1001) with indices 5:995

julia> r2 = OffsetArray(5:2:80, 40)
5:2:79 with indices 41:78

julia> r12 = r1[r2]
12:2:86 with indices 41:78

julia> first(r1[r2]) == r1[first(r2)]
false
```

After this PR:
```julia
julia> r12 = r1[r2]
11:2:85 with indices 41:78

julia> first(r1[r2]) == r1[first(r2)]
true
```

2. Fixes the indexing of `IdOffsetRange` with `AbstractUnitRanges` that do not have their axis starting at 1.

3. <strike>Changes the indexing behavior of `OffsetRanges` with `Colon` to avoid collecting the parent:

```julia
julia> r1[:]
11:1001 with indices 5:995
```

Technically this is breaking as the result becomes immutable, although it might be unusual to expect the result to be mutable in the first place given that it's not so  for ranges. This behavior is consistent with the idea that indexing into an `OffsetArray` with vector indices is equivalent to indexing its parent with the same indices, except the result has shifted axes.</strike> 

4. Fix indexing of `UnitRange`s with nested `IdentityUnitRange`s and `IdOffsetRange`s

On master:
```julia
julia> r1 = 1:1000;

julia> r2 = IdOffsetRange(IdOffsetRange(5:80, 2), 1)
OffsetArrays.IdOffsetRange(8:83)

julia> r1[r2]
OffsetArrays.IdOffsetRange(8:83)

julia> r1[r2] |> axes
(OffsetArrays.IdOffsetRange(2:77),)

julia> r2 |> axes
(OffsetArrays.IdOffsetRange(4:79),)

julia> r1[r2] |> axes == r2 |> axes
false
```

After this PR:
```julia
julia> r1[r2] |> axes
(OffsetArrays.IdOffsetRange(4:79),)

julia> r1[r2] |> axes == r2 |> axes
true
```