### PR TITLE
Do not specialize eachindex

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -227,7 +227,6 @@ Base.parent(A::OffsetArray) = A.parent
 # Base.Broadcast.BroadcastStyle(::Type{<:OffsetArray{<:Any, <:Any, AA}}) where AA = Base.Broadcast.BroadcastStyle(AA)
 
 @inline Base.size(A::OffsetArray) = size(parent(A))
-@inline Base.size(A::OffsetArray, d) = size(parent(A), d)
 
 @inline Base.axes(A::OffsetArray) = map(IdOffsetRange, axes(parent(A)), A.offsets)
 @inline Base.axes(A::OffsetArray, d) = d <= ndims(A) ? IdOffsetRange(axes(parent(A), d), A.offsets[d]) : IdOffsetRange(axes(parent(A), d))

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -226,9 +226,6 @@ Base.parent(A::OffsetArray) = A.parent
 #       The goal would be to have `OffsetArray(CuArray) .+ 1 == OffsetArray{CuArray}`.
 # Base.Broadcast.BroadcastStyle(::Type{<:OffsetArray{<:Any, <:Any, AA}}) where AA = Base.Broadcast.BroadcastStyle(AA)
 
-Base.eachindex(::IndexCartesian, A::OffsetArray) = CartesianIndices(axes(A))
-Base.eachindex(::IndexLinear, A::OffsetVector)   = axes(A, 1)
-
 @inline Base.size(A::OffsetArray) = size(parent(A))
 @inline Base.size(A::OffsetArray, d) = size(parent(A), d)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -714,6 +714,8 @@ end
     @test_throws DimensionMismatch OffsetArray(A0, 0:1, 2:4)
     @test eachindex(IndexLinear(), A) == eachindex(IndexLinear(), parent(A))
     @test eachindex(IndexCartesian(), A) == CartesianIndices(A)
+    A = ones(5:6)
+    @test eachindex(IndexLinear(), A) == 5:6
 end
 
 @testset "Scalar indexing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -713,9 +713,11 @@ end
     @test_throws DimensionMismatch OffsetArray(A0, 0:2, 3:4)
     @test_throws DimensionMismatch OffsetArray(A0, 0:1, 2:4)
     @test eachindex(IndexLinear(), A) == eachindex(IndexLinear(), parent(A))
-    @test eachindex(IndexCartesian(), A) == CartesianIndices(A)
+    @test eachindex(IndexCartesian(), A) == CartesianIndices(A) == CartesianIndices(axes(A))
+    @test eachindex(S) == eachindex(IndexCartesian(), S) == CartesianIndices(S)
+    @test eachindex(IndexLinear(), S) == eachindex(IndexLinear(), A0)
     A = ones(5:6)
-    @test eachindex(IndexLinear(), A) == 5:6
+    @test eachindex(IndexLinear(), A) === axes(A, 1)
 end
 
 @testset "Scalar indexing" begin


### PR DESCRIPTION
`OffsetArrays` does not need to specialize `eachindex` as the `Base` implementation for `AbstractArray`s has the same code. Similarly `size(::OffsetArray, d)` was repeating the code for `AbstractArray`s, and is not necessary.