### PR TITLE
Specialize copy and getindex with Colons

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,12 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 
 [compat]
 Adapt = "2, 3"
+Aqua = "0.5"
+CatIndices = "0.2"
+Documenter = "0.26"
+EllipsisNotation = "1"
+FillArrays = "0.11"
+StaticArrays = "1"
 julia = "0.7, 1"
 
 [extras]
@@ -15,9 +21,10 @@ CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "CatIndices", "DelimitedFiles", "Documenter", "Test", "LinearAlgebra", "EllipsisNotation", "StaticArrays"]
+test = ["Aqua", "CatIndices", "DelimitedFiles", "Documenter", "Test", "LinearAlgebra", "EllipsisNotation", "StaticArrays", "FillArrays"]

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -302,8 +302,14 @@ parentindex(r::IdOffsetRange, i) = i - r.offset
     @inbounds parent(A)[J...]
 end
 
-@propagate_inbounds Base.getindex(A::OffsetArray{<:Any,N}, c::Vararg{Colon,N}) where N = 
+@propagate_inbounds Base.getindex(A::OffsetArray{<:Any,N}, c::Vararg{Colon,N}) where N =
     OffsetArray(A.parent[c...], A.offsets)
+
+# With one Colon we use linear indexing.
+# In this case we may forward the index to the parent, as the information about the axes is lost
+# The exception to this is with OffsetVectors where the axis information is preserved,
+# but that case is handled by getindex(::OffsetArray{<:Any,N}, ::Vararg{Colon,N})
+@propagate_inbounds Base.getindex(A::OffsetArray, c::Colon) = A.parent[:]
 
 @inline function Base.getindex(A::OffsetVector, i::Int)
     @boundscheck checkbounds(A, i)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -380,9 +380,6 @@ for OR in [:IIUR, :IdOffsetRange]
     end
 end
 
-# This is technically breaking, so it might be incorporated in the next major release
-# Base.getindex(a::OffsetRange, ::Colon) = OffsetArray(a.parent[:], a.offsets)
-
 # mapreduce is faster with an IdOffsetRange than with an OffsetUnitRange
 # We therefore convert OffsetUnitRanges to IdOffsetRanges with the same values and axes
 function Base.mapreduce(f, op, As::OffsetUnitRange{<:Integer}...; kw...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using CatIndices: BidirectionalVector
 using EllipsisNotation
 using Adapt
 using StaticArrays
+using FillArrays
 
 DocMeta.setdocmeta!(OffsetArrays, :DocTestSetup, :(using OffsetArrays); recursive=true)
 
@@ -833,8 +834,21 @@ end
     @test A[:, :] == S[:, :] == A
 
     r1 = OffsetArray(IdentityUnitRange(100:1000), 3)
-    r2 = r1[:]
-    @test r2 == r1
+    @test r1[:] === r1
+
+    r2 = r1[:,:]
+    @test axes(r2, 1) == axes(r1, 1)
+    @test same_value(r1, r2)
+
+    s = @SVector[i for i in 1:3]
+    so = OffsetArray(s, 3)
+    @test so[:] === so
+
+    a = Ones(3, 2, 1)
+    ao = OffsetArray(a, axes(a))
+    @test ao[:,:,:] === ao
+    @test same_value(ao[:], ao)
+    @test same_value(ao[:,:], ao)
 
     for r1 in Any[
         # AbstractArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -833,9 +833,12 @@ end
     @test A[1, [4,3]] == S[1, [4,3]] == [4,2]
     @test A[:, :] == S[:, :] == A
 
+    # Indexing a nD OffsetArray with n colons preserves the type
     r1 = OffsetArray(IdentityUnitRange(100:1000), 3)
     @test r1[:] === r1
 
+    # In general with more colons than dimensions,
+    # the type might not be preserved but the values and the leading axes should be
     r2 = r1[:,:]
     @test axes(r2, 1) == axes(r1, 1)
     @test same_value(r1, r2)
@@ -849,6 +852,18 @@ end
     @test ao[:,:,:] === ao
     @test same_value(ao[:], ao)
     @test same_value(ao[:,:], ao)
+
+    # Indexing an nD OffsetArray with one Colon preserves only the values.
+    # This uses linear indexing
+    a = ones(2:3, 2:3)
+    b = a[:]
+    @test same_value(a, b)
+
+    vals = (1,2,3,4,5,6,7,8)
+    s = SArray{Tuple{2,2,2},Int,3,8}(vals)
+    so = OffsetArray(s, axes(s));
+    so2 = so[:]
+    @test same_value(so2, s)
 
     for r1 in Any[
         # AbstractArrays


### PR DESCRIPTION
There are a couple of changes that I have removed from other PRs, as they are potentially breaking (leads to changes in return types). We may consider these for version 2.0 (or perhaps a 1.x minor release if these are not considered breaking).

1. `copy` is forwarded to the parent. This preserves the type of the parent in case there is a special structure associated with it. For example:

On master:
```julia
julia> a = [1,2]';

julia> ao = OffsetArray(a, axes(a));

julia> copy(a) # produces an Adjoint
1×2 Adjoint{Int64,Array{Int64,1}}:
 1  2

julia> copy(ao) # produces a 1-row matrix with offset axes
1×2 OffsetArray(::Array{Int64,2}, 1:1, 1:2) with eltype Int64 with indices 1:1×1:2:
 1  2
```

The `copy` operation on the `Adjoint` of an `AbstractVector` preserves its type, as a row-vector is distinct from a 1-row matrix. However `OffsetArray`s do not preserve this type information. Also for immutable parent structs such as `AbstarctRange`s and `StaticArray`s, the `copy` appears to not respect the parent's behavior:

```julia
julia> s = @SVector[i for i in 1:3]; so = OffsetArray(s, 3); # StaticArray

julia> copy(s) # produces an SArray
3-element SArray{Tuple{3},Int64,1,3} with indices SOneTo(3):
 1
 2
 3

julia> copy(so) # no longer static
3-element OffsetArray(::Array{Int64,1}, 4:6) with eltype Int64 with indices 4:6:
 1
 2
 3

julia> f = Fill(3, 2, 2); fo = OffsetArray(f, axes(f)); # FillArray

julia> copy(f) # produces a FillArray
2×2 Fill{Int64}: entries equal to 3

julia> copy(fo) # produces a dense array
2×2 OffsetArray(::Array{Int64,2}, 1:2, 1:2) with eltype Int64 with indices 1:2×1:2:
 3  3
 3  3

julia> r = 1:3; ro = OffsetArray(r, 2);

julia> copy(r) # produces a UnitRange
1:3

julia> copy(ro) # produces a dense array
3-element OffsetArray(::Array{Int64,1}, 3:5) with eltype Int64 with indices 3:5:
 1
 2
 3
``` 

After this PR:
```julia
julia> copy(ao)
1×2 OffsetArray(::Adjoint{Int64,Array{Int64,1}}, 1:1, 1:2) with eltype Int64 with indices 1:1×1:2:
 1  2

julia> copy(so)
3-element OffsetArray(::SArray{Tuple{3},Int64,1,3}, 4:6) with eltype Int64 with indices 4:6:
 1
 2
 3

julia> copy(fo)
2×2 OffsetArray(::Fill{Int64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}, 1:2, 1:2) with eltype Int64 with indices 1:2×1:2:
 3  3
 3  3

julia> copy(ro)
1:3 with indices 3:5
```

2. `getindex` with as many `Colon`s as the number of dimensions may preserve the type of the parent. This operation is similar to `copy`, and in the case of `AbstactRange`s it's actually implemented as as a `copy`.

```julia
julia> ao[:,:]
1×2 OffsetArray(::Adjoint{Int64,Array{Int64,1}}, 1:1, 1:2) with eltype Int64 with indices 1:1×1:2:
 1  2

julia> so[:]
3-element OffsetArray(::SArray{Tuple{3},Int64,1,3}, 4:6) with eltype Int64 with indices 4:6:
 1
 2
 3
```