### PR TITLE
Fix indexing with Slice

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -349,17 +349,17 @@ end
 
 for OR in [:IIUR, :IdOffsetRange]
     for R in [:StepRange, :StepRangeLen, :LinRange, :UnitRange]
-        @eval @propagate_inbounds Base.getindex(r::$R, s::$OR) = OffsetArray(r[no_offset_view(s)], axes(s))
+        @eval @propagate_inbounds Base.getindex(r::$R, s::$OR) = OffsetArray(r[UnitRange(s)], axes(s))
     end
 
     # this method is needed for ambiguity resolution
     @eval @propagate_inbounds Base.getindex(r::StepRangeLen{T,<:Base.TwicePrecision,<:Base.TwicePrecision}, s::$OR) where T =
-    OffsetArray(r[no_offset_view(s)], axes(s))
+    OffsetArray(r[UnitRange(s)], axes(s))
 
     #= Integer UnitRanges may return an appropriate AbstractUnitRange{<:Integer}, as the result may be used in indexing, and
     indexing is faster with ranges =#
     @eval @propagate_inbounds function Base.getindex(r::UnitRange{<:Integer}, s::$OR)
-        rs = r[no_offset_view(s)]
+        rs = r[UnitRange(s)]
         offset_s = first(axes(s,1)) - 1
         IdOffsetRange(UnitRange(rs .- offset_s), offset_s)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -880,7 +880,7 @@ end
         LinRange(1, 99, 99),
         ]
 
-        for r2 in [
+        for r2 in Any[
             IdentityUnitRange(Base.OneTo(10)),
             Base.Slice(Base.OneTo(10)),
             IdOffsetRange(Base.OneTo(10)),
@@ -1221,7 +1221,7 @@ end
     @test String(take!(io)) == "3:5 with indices 0:2"
 
     # issue #198
-    for r in [axes(OffsetVector(1:10, -5), 1), 1:1:2, 1.0:1.0:2.0, 1:-1:-5]
+    for r in Any[axes(OffsetVector(1:10, -5), 1), 1:1:2, 1.0:1.0:2.0, 1:-1:-5]
         a = OffsetVector(r, 5)
         show(io, a)
         @test String(take!(io)) == "$r with indices $(UnitRange(axes(a,1)))"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -861,6 +861,24 @@ end
             test_indexing_axes_and_vals(r1, r2)
         end
     end
+
+    # Indexing with IdentityUnitRange(::Base.OneTo) is special as this has 1-based  
+    # indices and the indexing operation leads to the correct axes in Base.
+    # The result should not be changed in this package.
+    # Also Issue 209 for versions v"1,0.x"
+    for r1 in [
+        UnitRange(1.0, 99.0), 
+        1:99, 
+        1:1:99, 
+        1.0:1.0:99.0, 
+        StepRangeLen(Float64(1), Float64(99), 99),
+        LinRange(1, 99, 99),
+        ]
+
+        for r2 in [IdentityUnitRange(Base.OneTo(10))]
+            test_indexing_axes_and_vals(r1, r2)
+        end
+    end
 end
 
 @testset "Vector indexing with offset ranges" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -867,10 +867,10 @@ end
     # The result should not be changed in this package.
     # Also Issue 209 for versions v"1,0.x"
     for r1 in [
-        UnitRange(1.0, 99.0), 
-        1:99, 
-        1:1:99, 
-        1.0:1.0:99.0, 
+        UnitRange(1.0, 99.0),
+        1:99,
+        1:1:99,
+        1.0:1.0:99.0,
         StepRangeLen(Float64(1), Float64(99), 99),
         LinRange(1, 99, 99),
         ]


### PR DESCRIPTION
Fixes #209 

On master and Julia 1.0

```julia
julia> using OffsetArrays

julia> r = 1:2:10
1:2:9

julia> r[Base.Slice(Base.OneTo(3))]
ERROR: StackOverflowError:
Stacktrace:
 [1] getindex(::StepRange{Int64,Int64}, ::Base.Slice{Base.OneTo{Int64}}) at /home/jishnu/Dropbox/JuliaPackages/OffsetArrays.jl/src/OffsetArrays.jl:352 (repeats 80000 times)
```

After this PR:

```julia
julia> using OffsetArrays

julia> r = 1:2:10
1:2:9

julia> r[Base.Slice(Base.OneTo(3))]
1:2:5 with indices 1:3
```