### PR TITLE
Preserve Slice(::OneTo) in no_offset_view

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -355,7 +355,7 @@ for OR in [:IIUR, :IdOffsetRange]
     # this method is needed for ambiguity resolution
     @eval @propagate_inbounds Base.getindex(r::StepRangeLen{T,<:Base.TwicePrecision,<:Base.TwicePrecision}, s::$OR) where T =
     OffsetArray(r[no_offset_view(s)], axes(s))
-    
+
     #= Integer UnitRanges may return an appropriate AbstractUnitRange{<:Integer}, as the result may be used in indexing, and
     indexing is faster with ranges =#
     @eval @propagate_inbounds function Base.getindex(r::UnitRange{<:Integer}, s::$OR)
@@ -437,7 +437,9 @@ julia> A
 """
 no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
 if isdefined(Base, :IdentityUnitRange)
-    no_offset_view(a::Base.Slice) = Base.Slice(UnitRange(a))  # valid only if Slice is distinguished from IdentityUnitRange
+    # valid only if Slice is distinguished from IdentityUnitRange
+    no_offset_view(a::Base.Slice{<:Base.OneTo}) = a
+    no_offset_view(a::Base.Slice) = Base.Slice(UnitRange(a))
     no_offset_view(S::SubArray) = view(parent(S), map(no_offset_view, parentindices(S))...)
 end
 no_offset_view(a::Array) = a

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1118,6 +1118,14 @@ end
     a = OffsetArray(1:3, 0:2);
     b = @view a[0]
     @test b[] == b[1] == 1
+
+    a = reshape(1:16, 4, 4);
+    for ax1 in (:, axes(a,1), UnitRange(axes(a,1))),
+        ax2 in (:, axes(a,2), UnitRange(axes(a,2)))
+            av = @view a[ax1, ax2]
+            av_nooffset = OffsetArrays.no_offset_view(av)
+            @test axes(av_nooffset) === axes(av)
+    end
 end
 
 @testset "iteration" begin


### PR DESCRIPTION
This introduces a specialization in `no_offset_view` to preserve the axes of `Array` views constructed using `Colon`s as indices.

On master:
```julia
julia> a = reshape(1:16, 4, 4);

julia> av = @view a[:,:];

julia> av_nooffset = OffsetArrays.no_offset_view(av);

julia> axes(av)
(Base.OneTo(4), Base.OneTo(4))

julia> axes(av_nooffset)
(Base.IdentityUnitRange(1:4), Base.IdentityUnitRange(1:4))
```

After this PR:
```julia
julia> av_nooffset = OffsetArrays.no_offset_view(av);

julia> axes(av_nooffset)
(Base.OneTo(4), Base.OneTo(4))

julia> av_nooffset === av
true
```