### PR TITLE
similar with IdOffsetRanges may use the parent axes types

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -263,7 +263,7 @@ end
 _similar(A, T, ax, ::Any) = similar(A, T, ax)
 _similar(AT, ax, ::Any) = similar(AT, ax)
 # Handle the general case by resorting to lengths along each axis
-# This is hit if none of the axes provided to similar(A, T, axes) is an IdOffsetRange,
+# This is hit if none of the axes provided to similar(A, T, axes) are IdOffsetRanges,
 # and if similar(A, T, axes::AX) is not defined for the type AX.
 # In this case the best that we can do is to create an Array of the correct size
 _similar(A, T, ax::I, ::I) where {I} = similar(A, T, map(_indexlength, ax))

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -248,16 +248,16 @@ Base.similar(A::OffsetArray, ::Type{T}, dims::Dims) where T =
 function Base.similar(A::AbstractArray, ::Type{T}, shape::Tuple{OffsetAxisKnownLength,Vararg{OffsetAxisKnownLength}}) where T
     # strip IdOffsetRanges to extract the parent range and use it to generate the array
     new_shape = map(_strip_IdOffsetRange, shape)
-    # route through _similar_axesorlength to avoid a stack overflow if map(_strip_IdOffsetRange, shape) === shape
+    # route through _similar_axes_or_length to avoid a stack overflow if map(_strip_IdOffsetRange, shape) === shape
     # This tries to use new_shape directly in similar if similar(A, T, ::typeof(new_shape)) is defined
     # If this fails, it calls similar(A, T, map(_indexlength, new_shape)) to use the size along each axis
     # to generate the new array
-    P = _similar_axesorlength(A, T, new_shape, shape)
+    P = _similar_axes_or_length(A, T, new_shape, shape)
     return OffsetArray(P, map(_offset, axes(P), shape))
 end
 function Base.similar(::Type{T}, shape::Tuple{OffsetAxisKnownLength,Vararg{OffsetAxisKnownLength}}) where {T<:AbstractArray}
     new_shape = map(_strip_IdOffsetRange, shape)
-    P = _similar_axesorlength(T, new_shape, shape)
+    P = _similar_axes_or_length(T, new_shape, shape)
     OffsetArray(P, map(_offset, axes(P), shape))
 end
 # Try to use the axes to generate the parent array type
@@ -265,14 +265,14 @@ end
 # This method is hit if at least one axis provided to similar(A, T, axes) is an IdOffsetRange
 # For example this is hit when similar(A::OffsetArray) is called,
 # which expands to similar(A, eltype(A), axes(A))
-_similar_axesorlength(A, T, ax, ::Any) = similar(A, T, ax)
-_similar_axesorlength(AT, ax, ::Any) = similar(AT, ax)
+_similar_axes_or_length(A, T, ax, ::Any) = similar(A, T, ax)
+_similar_axes_or_length(AT, ax, ::Any) = similar(AT, ax)
 # Handle the general case by resorting to lengths along each axis
 # This is hit if none of the axes provided to similar(A, T, axes) are IdOffsetRanges,
 # and if similar(A, T, axes::AX) is not defined for the type AX.
 # In this case the best that we can do is to create a mutable array of the correct size
-_similar_axesorlength(A, T, ax::I, ::I) where {I} = similar(A, T, map(_indexlength, ax))
-_similar_axesorlength(AT, ax::I, ::I) where {I} = similar(AT, map(_indexlength, ax))
+_similar_axes_or_length(A, T, ax::I, ::I) where {I} = similar(A, T, map(_indexlength, ax))
+_similar_axes_or_length(AT, ax::I, ::I) where {I} = similar(AT, map(_indexlength, ax))
 
 # reshape accepts a single colon
 Base.reshape(A::AbstractArray, inds::OffsetAxis...) = reshape(A, inds)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -253,9 +253,14 @@ function Base.similar(A::AbstractArray, ::Type{T}, inds::Tuple{OffsetAxisKnownLe
 end
 # Try to use the axes to generate the parent array type
 # This is useful if the axes have special meanings, such as with static arrays
-# This method is hit if one of the axes provided to similar(A, T, axes) is an IdOffsetRange
+# This method is hit if at least one axis provided to similar(A, T, axes) is an IdOffsetRange
+# For example this is hit when similar(A::OffsetArray) is called,
+# which expands to similar(A, eltype(A), axes(A))
 _similar(A, T, ax, ::Any) = similar(A, T, ax)
 # Handle the general case by resorting to lengths along each axis
+# This is hit if none of the axes provided to similar(A, T, axes) is an IdOffsetRange,
+# and if similar(A, T, axes::AX) is not defined for the type AX.
+# In this case the best that we can do is to create an Array of the correct size
 _similar(A, T, ax::I, ::I) where {I} = similar(A, T, map(_indexlength, ax))
 
 # reshape accepts a single colon

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -265,7 +265,7 @@ _similar(AT, ax, ::Any) = similar(AT, ax)
 # Handle the general case by resorting to lengths along each axis
 # This is hit if none of the axes provided to similar(A, T, axes) are IdOffsetRanges,
 # and if similar(A, T, axes::AX) is not defined for the type AX.
-# In this case the best that we can do is to create an Array of the correct size
+# In this case the best that we can do is to create a mutable array of the correct size
 _similar(A, T, ax::I, ::I) where {I} = similar(A, T, map(_indexlength, ax))
 _similar(AT, ax::I, ::I) where {I} = similar(AT, map(_indexlength, ax))
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -249,6 +249,11 @@ function Base.similar(A::AbstractArray, ::Type{T}, inds::Tuple{OffsetAxisKnownLe
     B = similar(A, T, map(_indexlength, inds))
     return OffsetArray(B, map(_offset, axes(B), inds))
 end
+# IdOffsetRanges retain the types of the parent axes, so we may construct an appropriate similar array using these
+function Base.similar(A::AbstractArray, ::Type{T}, inds::Tuple{IdOffsetRange,Vararg{IdOffsetRange}}) where T
+    B = similar(A, T, map(parent, inds))
+    return OffsetArray(B, map(_offset, axes(B), inds))
+end
 
 # reshape accepts a single colon
 Base.reshape(A::AbstractArray, inds::OffsetAxis...) = reshape(A, inds)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,6 +7,9 @@ _indexlength(r::AbstractRange) = length(r)
 _indexlength(i::Integer) = i
 _indexlength(i::Colon) = Colon()
 
+_maybeparent(r::IdOffsetRange) = parent(r)
+_maybeparent(r) = r
+
 _offset(axparent::AbstractUnitRange, ax::AbstractUnitRange) = first(ax) - first(axparent)
 _offset(axparent::AbstractUnitRange, ax::Integer) = 1 - first(axparent)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,8 +7,8 @@ _indexlength(r::AbstractRange) = length(r)
 _indexlength(i::Integer) = i
 _indexlength(i::Colon) = Colon()
 
-_maybeparent(r::IdOffsetRange) = parent(r)
-_maybeparent(r) = r
+_strip_IdOffsetRange(r::IdOffsetRange) = parent(r)
+_strip_IdOffsetRange(r) = r
 
 _offset(axparent::AbstractUnitRange, ax::AbstractUnitRange) = first(ax) - first(axparent)
 _offset(axparent::AbstractUnitRange, ax::Integer) = 1 - first(axparent)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1287,6 +1287,7 @@ end
     s = @SVector[i for i in 1:10]
     so = OffsetArray(s, 4);
     @test typeof(parent(similar(so))) == typeof(similar(s))
+    @test typeof(parent(similar(so, eltype(so), axes(so)))) == typeof(similar(s))
 
     @test_throws MethodError similar(A, (:,))
     @test_throws MethodError similar(A, (: ,:))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1284,6 +1284,10 @@ end
     @test isa(B, OffsetArray{Int, 2})
     @test axes(B) == (0:0, 1:3)
 
+    s = @SVector[i for i in 1:10]
+    so = OffsetArray(s, 4);
+    @test typeof(parent(similar(so))) == typeof(similar(s))
+
     @test_throws MethodError similar(A, (:,))
     @test_throws MethodError similar(A, (: ,:))
     @test_throws MethodError similar(A, (: ,2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1289,6 +1289,29 @@ end
     @test typeof(parent(similar(so))) == typeof(similar(s))
     @test typeof(parent(similar(so, eltype(so), axes(so)))) == typeof(similar(s))
 
+    s = SArray{Tuple{2,2,2},Int,3,8}((1,2,3,4,5,6,7,8))
+    so = OffsetArray(s, 0, 0, 0)
+    A = similar(so)
+    @test A isa OffsetArray
+    @test parent(A) isa StaticArray
+    for ax in Any[(axes(s,1), axes(so)[2:3]...), (axes(so,1), axes(s)[2:3]...)]
+        A = similar(so, Int, ax)
+        @test A isa OffsetArray
+        @test parent(A) isa StaticArray
+        @test axes(A) == ax
+    end
+
+    # check with an unseen axis type
+    A = similar(ones(1), Int, ZeroBasedUnitRange(3:4), 4:5)
+    @test eltype(A) === Int
+    @test axes(A) == (3:4, 4:5)
+    A = similar(ones(1), Int, IdOffsetRange(ZeroBasedUnitRange(3:4), 2), 4:5)
+    @test eltype(A) === Int
+    @test axes(A) == (5:6, 4:5)
+    A = similar(ones(1), Int, IdOffsetRange(ZeroBasedUnitRange(3:4), 2), 4)
+    @test eltype(A) === Int
+    @test axes(A) == (5:6, 1:4)
+
     @test_throws MethodError similar(A, (:,))
     @test_throws MethodError similar(A, (: ,:))
     @test_throws MethodError similar(A, (: ,2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1312,6 +1312,17 @@ end
     @test eltype(A) === Int
     @test axes(A) == (5:6, 1:4)
 
+    # test for similar(::Type, ax)
+    indsoffset = (IdOffsetRange(SOneTo(2), 2),)
+    A = similar(Array{Int}, indsoffset)
+    @test parent(A) isa StaticArray
+    @test axes(A) == (3:4,)
+
+    s = SArray{Tuple{2,2},Int,2,4}((1,2,3,4));
+    so = OffsetArray(s, 2, 2);
+    so2 = so .+ 1;
+    @test parent(so2) isa StaticArray
+
     @test_throws MethodError similar(A, (:,))
     @test_throws MethodError similar(A, (: ,:))
     @test_throws MethodError similar(A, (: ,2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1317,6 +1317,9 @@ end
     A = similar(Array{Int}, indsoffset)
     @test parent(A) isa StaticArray
     @test axes(A) == (3:4,)
+    A = similar(Array{Int}, (indsoffset..., SOneTo(3)))
+    @test parent(A) isa StaticArray
+    @test axes(A) == (3:4, 1:3)
 
     s = SArray{Tuple{2,2},Int,2,4}((1,2,3,4));
     so = OffsetArray(s, 2, 2);


### PR DESCRIPTION
Currently
```julia
julia> s = @SVector[i for i in 1:3]
3-element SArray{Tuple{3},Int64,1,3} with indices SOneTo(3):
 1
 2
 3

julia> so = OffsetArray(s, 4);

julia> similar(so)
3-element OffsetArray(::Array{Int64,1}, 5:7) with eltype Int64 with indices 5:7:
 139957917106072
 139957916617440
 139957916868864
```

After this PR:
```julia
julia> similar(so)
3-element OffsetArray(::MArray{Tuple{3},Int64,1,3}, 5:7) with eltype Int64 with indices 5:7:
 139957418956176
               4
               0
```

The new array type is also statically sized, as the information about the size is preserved in the axes.