### PR TITLE
Limit specialized mapreduce to Integer OffsetUnitRanges

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -373,9 +373,9 @@ end
 
 # mapreduce is faster with an IdOffsetRange than with an OffsetUnitRange
 # We therefore convert OffsetUnitRanges to IdOffsetRanges with the same values and axes
-function Base.mapreduce(f, op, As::OffsetUnitRange...; kw...)
+function Base.mapreduce(f, op, As::OffsetUnitRange{<:Integer}...; kw...)
     ofs = map(A -> first(axes(A,1)) - 1, As)
-    AIds = map((A, of) -> IdOffsetRange(UnitRange(parent(A) .- of), of), As, ofs)
+    AIds = map((A, of) -> IdOffsetRange(UnitRange(parent(A)) .- of, of), As, ofs)
     mapreduce(f, op, AIds...; kw...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1521,7 +1521,7 @@ end
     @test clamp.(A, (amax+amin)/2, amax) == OffsetArray(clamp.(parent(A), (amax+amin)/2, amax), axes(A))
 
     @testset "mapreduce for OffsetRange" begin
-        for r in Any[5:100, IdOffsetRange(1:100, 4), IdOffsetRange(4:5), # AbstractUnitRanges
+        for r in Any[5:100, UnitRange(5.0, 20.0), IdOffsetRange(1:100, 4), IdOffsetRange(4:5), # AbstractUnitRanges
             2:4:14, 1.5:1.0:10.5, # AbstractRanges
             ]
 


### PR DESCRIPTION
Fixes a bug on master introduced by #202  
Currently:

```julia
julia> sum(OffsetVector(UnitRange(1.0, 3.0), 2:4), dims = 1)
ERROR: MethodError: no method matching UnitRange(::StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}})
```

After this PR:

```julia
julia> sum(OffsetVector(UnitRange(1.0, 3.0), 2:4), dims = 1)
1-element OffsetArray(::Array{Float64,1}, 2:2) with eltype Float64 with indices 2:2:
 6.0
```