### PR TITLE
Reshape accepts a single colon for AbstractArrays

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,8 +8,7 @@ _indexlength(i::Integer) = i
 _indexlength(i::Colon) = Colon()
 
 _offset(axparent::AbstractUnitRange, ax::AbstractUnitRange) = first(ax) - first(axparent)
-_offset(axparent::AbstractUnitRange, ax::Integer) = 1 - first(axparent)
-_offset(axparent::AbstractUnitRange, ::Colon) = 0
+_offset(axparent::AbstractUnitRange, ::Union{Integer, Colon}) = 1 - first(axparent)
 
 """
     OffsetArrays.AxisConversionStyle(typeof(indices))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,6 +9,7 @@ _indexlength(i::Colon) = Colon()
 
 _offset(axparent::AbstractUnitRange, ax::AbstractUnitRange) = first(ax) - first(axparent)
 _offset(axparent::AbstractUnitRange, ax::Integer) = 1 - first(axparent)
+_offset(axparent::AbstractUnitRange, ::Colon) = 0
 
 """
     OffsetArrays.AxisConversionStyle(typeof(indices))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1370,6 +1370,20 @@ end
     @test axes(B, 1) == -10:-9
     @test axes(B, 2) == axes(A0, 2)
 
+    B = reshape(A0, -10:-9, 3:3, :)
+    @test B isa OffsetArray{Int,3}
+    @test same_value(A0, B)
+    @test axes(B, 1) == -10:-9
+    @test axes(B, 2) == 3:3
+    @test axes(B, 3) == 1:2
+
+    B = reshape(A0, -10:-9, 3:4, :)
+    @test B isa OffsetArray{Int,3}
+    @test same_value(A0, B)
+    @test axes(B, 1) == -10:-9
+    @test axes(B, 2) == 3:4
+    @test axes(B, 3) == 1:1
+
     # pop the parent
     B = reshape(A, size(A))
     @test B == A0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1363,6 +1363,13 @@ end
     @test reshape(OffsetArray(-1:0, -1:0), :) == OffsetArray(-1:0, -1:0)
     @test reshape(A, :) == reshape(A0, :)
 
+    # reshape with one Colon for AbstractArrays
+    B = reshape(A0, -10:-9, :)
+    @test B isa OffsetArray{Int,2}
+    @test parent(B) === A0
+    @test axes(B, 1) == -10:-9
+    @test axes(B, 2) == axes(A0, 2)
+
     # pop the parent
     B = reshape(A, size(A))
     @test B == A0


### PR DESCRIPTION
Currently this is broken as `reshape` uses `_offset` to compute the offsets, but that function doesn't accept `Colon`s. This PR fixes this.

Now:
```julia
julia> A0 = [1 3; 2 4]
2×2 Array{Int64,2}:
 1  3
 2  4

julia> reshape(A0, 2:3, :)
2×2 OffsetArray(::Array{Int64,2}, 2:3, 1:2) with eltype Int64 with indices 2:3×1:2:
 1  3
 2  4
``` 

I'm not totally sure if the fix is correct, but `reshape` is pretty broken for non 1-based arrays to add more tests.