### PR TITLE
Add similar(::OffsetArray) and similar(::OffsetArray, T)

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -269,6 +269,8 @@ if VERSION < v"1.6"
     end
 end
 
+Base.similar(A::OffsetArray) = OffsetArray(similar(parent(A)), A.offsets)
+Base.similar(A::OffsetArray, ::Type{T}) where T = OffsetArray(similar(parent(A), T), A.offsets)
 Base.similar(A::OffsetArray, ::Type{T}, dims::Dims) where T =
     similar(parent(A), T, dims)
 function Base.similar(A::AbstractArray, ::Type{T}, shape::Tuple{OffsetAxisKnownLength,Vararg{OffsetAxisKnownLength}}) where T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1439,6 +1439,19 @@ end
     so2 = so .+ 1;
     @test parent(so2) isa StaticArray
 
+    # test for similar(::OffsetArray)
+    d = Diagonal(1:4)
+    od = OffsetArray(d, 2, 3)
+    od2 = similar(od)
+    @test od2 isa OffsetMatrix{Int}
+    @test parent(od2) isa Diagonal
+    @test axes(od2) == axes(od)
+    # test for similar(::OffsetArray, T)
+    od2 = similar(od, Float64)
+    @test od2 isa OffsetMatrix{Float64}
+    @test axes(od2) == axes(od)
+    @test parent(od2) isa Diagonal
+
     @test_throws MethodError similar(A, (:,))
     @test_throws MethodError similar(A, (: ,:))
     @test_throws MethodError similar(A, (: ,2))


### PR DESCRIPTION
This is usually not necessary, but some types such as `Diagonal` do not define `similar` with axes specified. So currently:

```julia
julia> d = Diagonal(1:4);

julia> od = OffsetArray(d, 0, 0);

julia> od |> parent |> eigvals
1:4

julia> copy(od) |> parent |> eigvals
ERROR: MethodError: no method matching eigvals!(::SparseArrays.SparseMatrixCSC{Float64,Int64})
```

After this PR:
```julia
julia> copy(od) |> parent |> eigvals
4-element Array{Int64,1}:
 1
 2
 3
 4
```