### PR TITLE
Logical indexing for IdOffsetRange

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -201,17 +201,7 @@ end
     offset_s = first(axes(s,1)) - 1
     if eltype(s) === Bool
         # Use logical indexing
-        if length(s) == 0 # true:false
-            return range(first(r), length = 0)
-        elseif length(s) == 1 # true:true or false:false
-            if first(s) # true:true
-                return range(first(r), length = 1)
-            else # false:false
-                return range(first(r), length = 0)
-            end
-        else # length(s) == 2 (false:true)
-            return range(last(r), length = 1)
-        end
+        range(first(r) * first(s) + last(r) * !first(s), length=Int(last(s)))
     else
         @inbounds pr = r.parent[s .- r.offset] .+ r.offset
         return _indexedby(pr, axes(s))
@@ -222,17 +212,7 @@ end
     @boundscheck checkbounds(r, s)
     if eltype(s) === Bool
         # Use logical indexing
-        if length(s) == 0 # eg. true:true:false
-            return range(first(r), step = oneunit(step(s)), length = 0)
-        elseif length(s) == 1 # eg. true:true:true or false:true:false
-            if first(s) # eg. true:true:true
-                return range(first(r), step = oneunit(step(s)), length = 1)
-            else # eg. false:true:false
-                return range(first(r), step = oneunit(step(s)), length = 0)
-            end
-        else # length(s) == 2 (eg. false:true:true)
-            return range(last(r), step = oneunit(step(s)), length = 1)
-        end
+        range(first(r) * first(s) + last(r) * !first(s), step = oneunit(step(s)), length=Int(last(s)))
     else
         @inbounds rs = r.parent[s .- r.offset] .+ r.offset
         return no_offset_view(rs)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -201,6 +201,12 @@ end
     offset_s = first(axes(s,1)) - 1
     if eltype(s) === Bool
         # Use logical indexing
+        #= The code implemented is a comparison-free version of the following:
+
+        range(ifelse(first(s), first(r), last(r)), length=Int(last(s)))
+
+        See https://github.com/JuliaArrays/OffsetArrays.jl/pull/224#discussion_r595635143
+        =#
         range(first(r) * first(s) + last(r) * !first(s), length=Int(last(s)))
     else
         @inbounds pr = r.parent[s .- r.offset] .+ r.offset
@@ -212,6 +218,12 @@ end
     @boundscheck checkbounds(r, s)
     if eltype(s) === Bool
         # Use logical indexing
+        #= The code implemented is a comparison-free version of the following:
+
+        range(ifelse(first(s), first(r), last(r)), step = oneunit(step(s)), length=Int(last(s)))
+
+        See https://github.com/JuliaArrays/OffsetArrays.jl/pull/224#discussion_r595635143
+        =#
         range(first(r) * first(s) + last(r) * !first(s), step = oneunit(step(s)), length=Int(last(s)))
     else
         @inbounds rs = r.parent[s .- r.offset] .+ r.offset

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -203,11 +203,10 @@ The code implemented is a branch-free version of the following:
 
 See https://github.com/JuliaArrays/OffsetArrays.jl/pull/224#discussion_r595635143
 
-Logical indexing does not preserve axes in general, except if all elements are true
+Logical indexing does not preserve indices, unlike other forms of vector indexing
 =#
 @inline function _getindex(r, s::AbstractUnitRange{Bool})
-    rs = range(first(r) * first(s) + last(r) * !first(s), length=Int(last(s)))
-    _indexedby(rs, axes(s))
+    range(first(r) * first(s) + last(r) * !first(s), length=Int(last(s)))
 end
 @inline function _getindex(r, s::StepRange{Bool})
     range(first(r) * first(s) + last(r) * !first(s), step = oneunit(step(s)), length=Int(last(s)))

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -77,13 +77,17 @@ struct IdOffsetRange{T<:Integer,I<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
     parent::I
     offset::T
 
-    function IdOffsetRange{T,I}(r::I, offset::T) where {T<:Integer,I<:AbstractUnitRange{T}}
-        if T === Bool
+    function _bool_check(::Type{Bool}, r, offset)
+        if offset && (first(r) || last(r))
             # disallow the construction of IdOffsetRange{Bool, UnitRange{Bool}}(true:true, true)
-            if offset && (first(r) || last(r))
-                throw(ArgumentError("values = $r and offset = $offset can not produce a boolean range"))
-            end
+            throw(ArgumentError("values = $r and offset = $offset can not produce a boolean range"))
         end
+        return nothing
+    end
+    _bool_check(::Type, r, offset) = nothing
+
+    function IdOffsetRange{T,I}(r::I, offset::T) where {T<:Integer,I<:AbstractUnitRange{T}}
+        _bool_check(T, r, offset)
         new{T,I}(r, offset)
     end
 
@@ -92,12 +96,7 @@ struct IdOffsetRange{T<:Integer,I<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
     so it ends up calling itself if I <: IdOffsetRange.
     =#
     function IdOffsetRange{T,IdOffsetRange{T,I}}(r::IdOffsetRange{T,I}, offset::T) where {T<:Integer,I<:AbstractUnitRange{T}}
-        if T === Bool
-            # disallow the construction of IdOffsetRange{Bool, IdOffsetRange{Bool, UnitRange{Bool}}}(IdOffsetRange(true:true), true)
-            if offset && (first(r) || last(r))
-                throw(ArgumentError("values = $r and offset = $offset can not produce a boolean range"))
-            end
-        end
+        _bool_check(T, r, offset)
         new{T,IdOffsetRange{T,I}}(r, offset)
     end
 end
@@ -195,9 +194,22 @@ end
     @boundscheck checkbounds(r, i)
     @inbounds eltype(r)(r.parent[i - r.offset] + r.offset)
 end
+
 # Logical indexing following https://github.com/JuliaLang/julia/pull/31829
-@inline function Base.getindex(r::IdOffsetRange, s::AbstractUnitRange{<:Integer})
-    @boundscheck checkbounds(r, s)
+#= Helper function to perform logical indxeing for boolean ranges
+The code implemented is a branch-free version of the following:
+
+    range(first(s) ? first(r) : last(r), length=Int(last(s)))
+
+See https://github.com/JuliaArrays/OffsetArrays.jl/pull/224#discussion_r595635143
+=#
+@inline function _getindex(r, s::AbstractUnitRange{Bool})
+    range(first(r) * first(s) + last(r) * !first(s), length=Int(last(s)))
+end
+@inline function _getindex(r, s::StepRange{Bool})
+    range(first(r) * first(s) + last(r) * !first(s), step = oneunit(step(s)), length=Int(last(s)))
+end
+@inline function _getindex(r, s::AbstractUnitRange)
     offset_s = first(axes(s,1)) - 1
     if eltype(s) === Bool
         # Use logical indexing
@@ -213,21 +225,15 @@ end
         return _indexedby(pr, axes(s))
     end
 end
-# The following method is required to avoid falling back to getindex(::AbstractUnitRange, ::StepRange{<:Integer})
-@inline function Base.getindex(r::IdOffsetRange, s::StepRange{<:Integer})
-    @boundscheck checkbounds(r, s)
-    if eltype(s) === Bool
-        # Use logical indexing
-        #= The code implemented is a comparison-free version of the following:
+@inline function _getindex(r, s::StepRange)
+    @inbounds rs = r.parent[s .- r.offset] .+ r.offset
+    no_offset_view(rs)
+end
 
-        range(ifelse(first(s), first(r), last(r)), step = oneunit(step(s)), length=Int(last(s)))
-
-        See https://github.com/JuliaArrays/OffsetArrays.jl/pull/224#discussion_r595635143
-        =#
-        range(first(r) * first(s) + last(r) * !first(s), step = oneunit(step(s)), length=Int(last(s)))
-    else
-        @inbounds rs = r.parent[s .- r.offset] .+ r.offset
-        return no_offset_view(rs)
+for T in [:AbstractUnitRange, :StepRange]
+    @eval @inline function Base.getindex(r::IdOffsetRange, s::$T{<:Integer})
+        @boundscheck checkbounds(r, s)
+        _getindex(r, s)
     end
 end
 

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -77,13 +77,27 @@ struct IdOffsetRange{T<:Integer,I<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
     parent::I
     offset::T
 
-    IdOffsetRange{T,I}(r::I, offset::T) where {T<:Integer,I<:AbstractUnitRange{T}} = new{T,I}(r, offset)
+    function IdOffsetRange{T,I}(r::I, offset::T) where {T<:Integer,I<:AbstractUnitRange{T}}
+        if T === Bool
+            # disallow the construction of IdOffsetRange{Bool, UnitRange{Bool}}(true:true, true)
+            if offset && (first(r) || last(r))
+                throw(ArgumentError("values = $r and offset = $offset can not produce a boolean range"))
+            end
+        end
+        new{T,I}(r, offset)
+    end
 
     #= This method is necessary to avoid a StackOverflowError in IdOffsetRange{T,I}(r::IdOffsetRange, offset::Integer).
     The type signature in that method is more specific than IdOffsetRange{T,I}(r::I, offset::T),
     so it ends up calling itself if I <: IdOffsetRange.
     =#
     function IdOffsetRange{T,IdOffsetRange{T,I}}(r::IdOffsetRange{T,I}, offset::T) where {T<:Integer,I<:AbstractUnitRange{T}}
+        if T === Bool
+            # disallow the construction of IdOffsetRange{Bool, IdOffsetRange{Bool, UnitRange{Bool}}}(IdOffsetRange(true:true), true)
+            if offset && (first(r) || last(r))
+                throw(ArgumentError("values = $r and offset = $offset can not produce a boolean range"))
+            end
+        end
         new{T,IdOffsetRange{T,I}}(r, offset)
     end
 end
@@ -157,35 +171,75 @@ offset_coerce(::Type{I}, r::AbstractUnitRange) where I<:AbstractUnitRange =
 Base.reduced_index(i::IdOffsetRange) = typeof(i)(first(i):first(i))
 # Workaround for #92 on Julia < 1.4
 Base.reduced_index(i::IdentityUnitRange{<:IdOffsetRange}) = typeof(i)(first(i):first(i))
-for f in [:firstindex, :lastindex, :first, :last]
+for f in [:firstindex, :lastindex]
     @eval @inline Base.$f(r::IdOffsetRange) = $f(r.parent) + r.offset
+end
+for f in [:first, :last]
+    # coerce the type to deal with values that get promoted on addition (eg. Bool)
+    @eval @inline Base.$f(r::IdOffsetRange) = eltype(r)($f(r.parent) + r.offset)
 end
 
 @inline function Base.iterate(r::IdOffsetRange)
     ret = iterate(r.parent)
     ret === nothing && return nothing
-    return (ret[1] + r.offset, ret[2])
+    return (eltype(r)(ret[1] + r.offset), ret[2])
 end
 @inline function Base.iterate(r::IdOffsetRange, i)
     ret = iterate(r.parent, i)
     ret === nothing && return nothing
-    return (ret[1] + r.offset, ret[2])
+    return (eltype(r)(ret[1] + r.offset), ret[2])
 end
 
 @inline function Base.getindex(r::IdOffsetRange, i::Integer)
+    i isa Bool && throw(ArgumentError("invalid index: $i of type Bool"))
     @boundscheck checkbounds(r, i)
-    @inbounds r.parent[i - r.offset] + r.offset
+    @inbounds eltype(r)(r.parent[i - r.offset] + r.offset)
 end
+# Logical indexing following https://github.com/JuliaLang/julia/pull/31829
 @inline function Base.getindex(r::IdOffsetRange, s::AbstractUnitRange{<:Integer})
     @boundscheck checkbounds(r, s)
-    @inbounds pr = r.parent[_subtractoffset(s, r.offset)] .+ r.offset
-    _indexedby(pr, axes(s))
+    offset_s = first(axes(s,1)) - 1
+    if eltype(s) === Bool
+        # Use logical indexing
+        rs = if length(s) == 0 # true:false
+            UnitRange(r)
+        elseif length(s) == 1 # true:true or false:false
+            if first(s) # true:true
+                UnitRange(r)
+            else # false:false
+                UnitRange(range(first(r), length = 0))
+            end
+        else # length(s) == 2 (false:true)
+            f = first(r)
+            UnitRange(range(f + one(f), length = 1))
+        end
+        return _indexedby(rs, axes(s))
+    else
+        @inbounds pr = r.parent[s .- r.offset] .+ r.offset
+        return _indexedby(pr, axes(s))
+    end
 end
 # The following method is required to avoid falling back to getindex(::AbstractUnitRange, ::StepRange{<:Integer})
 @inline function Base.getindex(r::IdOffsetRange, s::StepRange{<:Integer})
     @boundscheck checkbounds(r, s)
-    @inbounds rs = r.parent[s .- r.offset] .+ r.offset
-    return no_offset_view(rs)
+    if eltype(s) === Bool
+        # Use logical indexing
+        rs = if length(s) == 0 # eg. true:true:false
+            range(first(r), step = step(s), length = 0)
+        elseif length(s) == 1 # eg. true:true:true or false:true:false
+            if first(s) # eg. true:true:true
+                range(first(r), step = step(s), length = 1)
+            else # eg. false:true:false
+                range(first(r), step = step(s), length = 0)
+            end
+        else # length(s) == 2 (eg. false:true:true)
+            range(first(r) + step(r), step = step(s), length = 1)
+        end
+        return no_offset_view(rs)
+    else
+        @inbounds rs = r.parent[s .- r.offset] .+ r.offset
+        return no_offset_view(rs)
+    end
 end
 
 # offset-preserve broadcasting

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -201,19 +201,17 @@ end
     offset_s = first(axes(s,1)) - 1
     if eltype(s) === Bool
         # Use logical indexing
-        rs = if length(s) == 0 # true:false
-            UnitRange(r)
+        if length(s) == 0 # true:false
+            return range(first(r), length = 0)
         elseif length(s) == 1 # true:true or false:false
             if first(s) # true:true
-                UnitRange(r)
+                return range(first(r), length = 1)
             else # false:false
-                UnitRange(range(first(r), length = 0))
+                return range(first(r), length = 0)
             end
         else # length(s) == 2 (false:true)
-            f = first(r)
-            UnitRange(range(f + one(f), length = 1))
+            return range(last(r), length = 1)
         end
-        return _indexedby(rs, axes(s))
     else
         @inbounds pr = r.parent[s .- r.offset] .+ r.offset
         return _indexedby(pr, axes(s))
@@ -224,18 +222,17 @@ end
     @boundscheck checkbounds(r, s)
     if eltype(s) === Bool
         # Use logical indexing
-        rs = if length(s) == 0 # eg. true:true:false
-            range(first(r), step = step(s), length = 0)
+        if length(s) == 0 # eg. true:true:false
+            return range(first(r), step = oneunit(step(s)), length = 0)
         elseif length(s) == 1 # eg. true:true:true or false:true:false
             if first(s) # eg. true:true:true
-                range(first(r), step = step(s), length = 1)
+                return range(first(r), step = oneunit(step(s)), length = 1)
             else # eg. false:true:false
-                range(first(r), step = step(s), length = 0)
+                return range(first(r), step = oneunit(step(s)), length = 0)
             end
         else # length(s) == 2 (eg. false:true:true)
-            range(first(r) + step(r), step = step(s), length = 1)
+            return range(last(r), step = oneunit(step(s)), length = 1)
         end
-        return no_offset_view(rs)
     else
         @inbounds rs = r.parent[s .- r.offset] .+ r.offset
         return no_offset_view(rs)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -77,15 +77,6 @@ struct IdOffsetRange{T<:Integer,I<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
     parent::I
     offset::T
 
-    function _bool_check(::Type{Bool}, r, offset)
-        if offset && (first(r) || last(r))
-            # disallow the construction of IdOffsetRange{Bool, UnitRange{Bool}}(true:true, true)
-            throw(ArgumentError("values = $r and offset = $offset can not produce a boolean range"))
-        end
-        return nothing
-    end
-    _bool_check(::Type, r, offset) = nothing
-
     function IdOffsetRange{T,I}(r::I, offset::T) where {T<:Integer,I<:AbstractUnitRange{T}}
         _bool_check(T, r, offset)
         new{T,I}(r, offset)
@@ -100,6 +91,15 @@ struct IdOffsetRange{T<:Integer,I<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
         new{T,IdOffsetRange{T,I}}(r, offset)
     end
 end
+
+function _bool_check(::Type{Bool}, r, offset)
+    # disallow the construction of IdOffsetRange{Bool, UnitRange{Bool}}(true:true, true)
+    if offset && (first(r) || last(r))
+        throw(ArgumentError("values = $r and offset = $offset can not produce a boolean range"))
+    end
+    return nothing
+end
+_bool_check(::Type, r, offset) = nothing
 
 # Construction/coercion from arbitrary AbstractUnitRanges
 function IdOffsetRange{T,I}(r::AbstractUnitRange, offset::Integer = 0) where {T<:Integer,I<:AbstractUnitRange{T}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -275,6 +275,9 @@ end
             @test first(r) === b1
             @test last(r) === b2
         end
+        @test_throws ArgumentError IdOffsetRange(true:true, true)
+        @test_throws ArgumentError IdOffsetRange{Bool,UnitRange{Bool}}(true:true, true)
+        @test_throws ArgumentError IdOffsetRange{Bool,IdOffsetRange{Bool,UnitRange{Bool}}}(IdOffsetRange(true:true), true)
     end
 
     @testset "Logical indexing" begin
@@ -314,34 +317,34 @@ end
         @testset "indexing wtih a Bool StepRange" begin
             r = IdOffsetRange(1:0)
 
-            @test r[true:true:false] == 1:0
+            @test r[true:true:false] == 1:1:0
             @test_throws BoundsError r[true:true:true]
             @test_throws BoundsError r[false:true:false]
             @test_throws BoundsError r[false:true:true]
 
             r = IdOffsetRange(1:1)
 
-            @test r[true:true:true] == 1:1
+            @test r[true:true:true] == 1:1:1
             @test r[true:true:true] == collect(r)[true:true:true]
 
-            @test r[false:true:false] == 1:0
+            @test r[false:true:false] == 1:1:0
             @test r[false:true:false] == collect(r)[false:true:false]
 
             # StepRange{Bool,Int}
             s = StepRange(true, 1, true)
-            @test r[s] == 1:1
+            @test r[s] == 1:1:1
             @test r[s] == collect(r)[s]
 
             s = StepRange(true, 2, true)
-            @test r[s] == 1:1
+            @test r[s] == 1:2:1
             @test r[s] == collect(r)[s]
 
             s = StepRange(false, 1, false)
-            @test r[s] == 1:0
+            @test r[s] == 1:1:0
             @test r[s] == collect(r)[s]
 
             s = StepRange(false, 2, false)
-            @test r[s] == 1:0
+            @test r[s] == 1:2:0
             @test r[s] == collect(r)[s]
 
             @test_throws BoundsError r[true:true:false]
@@ -349,12 +352,12 @@ end
 
             r = IdOffsetRange(1:2)
 
-            @test r[false:true:true] == 2:2
+            @test r[false:true:true] == 2:1:2
             @test r[false:true:true] == collect(r)[false:true:true]
 
             # StepRange{Bool,Int}
             s = StepRange(false, 1, true)
-            @test r[s] == 2:2
+            @test r[s] == 2:1:2
             @test r[s] == collect(r)[s]
 
             @test_throws BoundsError r[true:true:true]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -336,7 +336,7 @@ end
             @test r[s] == collect(r)[s]
 
             s = StepRange(true, 2, true)
-            @test r[s] == 1:2:1
+            @test r[s] == 1:1:1
             @test r[s] == collect(r)[s]
 
             s = StepRange(false, 1, false)
@@ -344,7 +344,7 @@ end
             @test r[s] == collect(r)[s]
 
             s = StepRange(false, 2, false)
-            @test r[s] == 1:2:0
+            @test r[s] == 1:1:0
             @test r[s] == collect(r)[s]
 
             @test_throws BoundsError r[true:true:false]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -268,6 +268,100 @@ end
             @test OrdinalRange{BigInt,BigInt}(r2) === r2
         end
     end
+
+    @testset "Bool IdOffsetRange (issue #223)" begin
+        for b1 in [false, true], b2 in [false, true]
+            r = IdOffsetRange(b1:b2)
+            @test first(r) === b1
+            @test last(r) === b2
+        end
+    end
+
+    @testset "Logical indexing" begin
+        @testset "indexing with a single bool" begin
+            r = IdOffsetRange(1:2)
+            @test_throws ArgumentError r[true]
+            @test_throws ArgumentError r[false]
+        end
+        @testset "indexing wtih a Bool UnitRange" begin
+            r = IdOffsetRange(1:0)
+
+            @test r[true:false] == 1:0
+            @test_throws BoundsError r[true:true]
+            @test_throws BoundsError r[false:false]
+            @test_throws BoundsError r[false:true]
+
+            r = IdOffsetRange(1:1)
+
+            @test r[true:true] == 1:1
+            @test r[true:true] == collect(r)[true:true]
+
+            @test r[false:false] == 1:0
+            @test r[false:false] == collect(r)[false:false]
+
+            @test_throws BoundsError r[true:false]
+            @test_throws BoundsError r[false:true]
+
+            r = IdOffsetRange(1:2)
+
+            @test r[false:true] == 2:2
+            @test r[false:true] == collect(r)[false:true]
+
+            @test_throws BoundsError r[true:true]
+            @test_throws BoundsError r[true:false]
+            @test_throws BoundsError r[false:false]
+        end
+        @testset "indexing wtih a Bool StepRange" begin
+            r = IdOffsetRange(1:0)
+
+            @test r[true:true:false] == 1:0
+            @test_throws BoundsError r[true:true:true]
+            @test_throws BoundsError r[false:true:false]
+            @test_throws BoundsError r[false:true:true]
+
+            r = IdOffsetRange(1:1)
+
+            @test r[true:true:true] == 1:1
+            @test r[true:true:true] == collect(r)[true:true:true]
+
+            @test r[false:true:false] == 1:0
+            @test r[false:true:false] == collect(r)[false:true:false]
+
+            # StepRange{Bool,Int}
+            s = StepRange(true, 1, true)
+            @test r[s] == 1:1
+            @test r[s] == collect(r)[s]
+
+            s = StepRange(true, 2, true)
+            @test r[s] == 1:1
+            @test r[s] == collect(r)[s]
+
+            s = StepRange(false, 1, false)
+            @test r[s] == 1:0
+            @test r[s] == collect(r)[s]
+
+            s = StepRange(false, 2, false)
+            @test r[s] == 1:0
+            @test r[s] == collect(r)[s]
+
+            @test_throws BoundsError r[true:true:false]
+            @test_throws BoundsError r[false:true:true]
+
+            r = IdOffsetRange(1:2)
+
+            @test r[false:true:true] == 2:2
+            @test r[false:true:true] == collect(r)[false:true:true]
+
+            # StepRange{Bool,Int}
+            s = StepRange(false, 1, true)
+            @test r[s] == 2:2
+            @test r[s] == collect(r)[s]
+
+            @test_throws BoundsError r[true:true:true]
+            @test_throws BoundsError r[true:true:false]
+            @test_throws BoundsError r[false:true:false]
+        end
+    end
 end
 
 # used in testing the constructor

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -299,7 +299,6 @@ end
 
             @test r[true:true] == 1:1
             @test r[true:true] == collect(r)[true:true]
-            @test axes(r[true:true], 1) == 1:1
 
             @test r[false:false] == 1:0
             @test r[false:false] == collect(r)[false:false]
@@ -336,7 +335,6 @@ end
             r = IdOffsetRange(10:10, 1)
             r2 = IdOffsetRange(false:false, 1) # effectively true:true with indices 2:2
             testlogicalindexing(r, r2)
-            @test axes(r[r2]) == axes(r2)
 
             r = IdOffsetRange(10:11)
             r2 = IdOffsetRange(false:true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -290,6 +290,7 @@ end
             r = IdOffsetRange(1:0)
 
             @test r[true:false] == 1:0
+            @test r[true:false] == collect(r)[true:false]
             @test_throws BoundsError r[true:true]
             @test_throws BoundsError r[false:false]
             @test_throws BoundsError r[false:true]
@@ -298,6 +299,7 @@ end
 
             @test r[true:true] == 1:1
             @test r[true:true] == collect(r)[true:true]
+            @test axes(r[true:true], 1) == 1:1
 
             @test r[false:false] == 1:0
             @test r[false:false] == collect(r)[false:false]
@@ -314,6 +316,32 @@ end
             @test_throws BoundsError r[true:false]
             @test_throws BoundsError r[false:false]
         end
+        @testset "indexing with a Bool IdOffsetRange" begin
+            # bounds-checking requires the axes of the indices to match that of the array
+            function testlogicalindexing(r, r2)
+                r3 = r[r2];
+                @test no_offset_view(r3) == collect(r)[collect(r2)]
+            end
+
+            r = IdOffsetRange(10:9)
+            r2 = IdOffsetRange(true:false)
+            testlogicalindexing(r, r2)
+
+            r = IdOffsetRange(10:10)
+            r2 = IdOffsetRange(false:false)
+            testlogicalindexing(r, r2)
+            r2 = IdOffsetRange(true:true)
+            testlogicalindexing(r, r2)
+
+            r = IdOffsetRange(10:10, 1)
+            r2 = IdOffsetRange(false:false, 1) # effectively true:true with indices 2:2
+            testlogicalindexing(r, r2)
+            @test axes(r[r2]) == axes(r2)
+
+            r = IdOffsetRange(10:11)
+            r2 = IdOffsetRange(false:true)
+            testlogicalindexing(r, r2)
+        end
         @testset "indexing wtih a Bool StepRange" begin
             r = IdOffsetRange(1:0)
 
@@ -326,6 +354,7 @@ end
 
             @test r[true:true:true] == 1:1:1
             @test r[true:true:true] == collect(r)[true:true:true]
+            @test axes(r[true:true:true], 1) == 1:1
 
             @test r[false:true:false] == 1:1:0
             @test r[false:true:false] == collect(r)[false:true:false]


### PR DESCRIPTION
Currently `(::IdOffsetRange)[::AbstractRange{Bool}]` is not implemented correctly, as the `Bool` ranges get promoted to `Int` ones when the offset is added to them. This PR fixes it so that the indexing represents logical indexing, and not standard linear indexing.

Also disables `(::IdOffsetRange)[::Bool]` in line with other ranges in `Base`. This should not be treated as a breaking change, as indexing an `IdOffsetRange` should be similar to indexing the collected `Vector`.

Before:
```julia
julia> r = IdOffsetRange(1:2)
IdOffsetRange(values=1:2, indices=1:2)

julia> r[false:true]
ERROR: BoundsError: attempt to access 2-element UnitRange{Int64} at index [0:1]

julia> collect(r)[false:true]
1-element Array{Int64,1}:
 2

julia> r[true]
1

julia> collect(r)[true]
ERROR: ArgumentError: invalid index: true of type Bool
```

Now:
```julia
julia> r[false:true]
2:2

julia> r[true]
ERROR: ArgumentError: invalid index: true of type Bool
```

The indexing is implemented here instead of being forwarded to the parent range because the behavior is broken in Base currently, and has only been fixed on nightly.

Also fixes #223 by coercing the `eltype` in indexing. Now 
```julia
julia> r = IdOffsetRange(true:true)
IdOffsetRange(values=true:true, indices=1:1)

julia> first(r)
true
```

Finally, this PR disallows the construction of `Bool` `IdOffsetRange`s where the `eltype` may not be preserved.

```julia
julia> IdOffsetRange(true:true, true)
ERROR: ArgumentError: values = true:true and offset = true can not produce a boolean range
```

Many of these behaviors are consistent with nightly but changes present behavior. However given that the present behavior is inconsistent, I wonder if it's worth replicating it instead of correcting it.