### PR TITLE
Origin accepts Integer arguments

### DIFF
--- a/src/origin.jl
+++ b/src/origin.jl
@@ -23,14 +23,15 @@ julia> OffsetArray(a, OffsetArrays.Origin(0)) # short notation for `Origin(0, 0)
  3  4
 ```
 """
-struct Origin{T<:Union{Tuple, Int}}
+struct Origin{T<:Union{Tuple{Vararg{Int}}, Int}}
     index::T
 end
-Origin(I::NTuple{N, Int}) where N = Origin{typeof(I)}(I)
-Origin(I::CartesianIndex) = Origin(I.I)
-Origin(I1::Int, In::Int...) = Origin((I1, In...))
+Origin(I::Tuple{Vararg{Int}}) = Origin{typeof(I)}(I)
+Origin(I::Tuple{Vararg{Integer}}) = Origin(map(Int, I))
+Origin(I::CartesianIndex) = Origin(Tuple(I))
+Origin(I::Integer...) = Origin(I)
 # Origin(0) != Origin((0, )) but they work the same with broadcasting
-Origin(n::Int) = Origin{Int}(n)
+Origin(n::Integer) = Origin{Int}(Int(n))
 
 (o::Origin)(A::AbstractArray) = o.index .- first.(axes(A))
 

--- a/src/origin.jl
+++ b/src/origin.jl
@@ -27,11 +27,11 @@ struct Origin{T<:Union{Tuple{Vararg{Int}}, Int}}
     index::T
 end
 Origin(I::Tuple{Vararg{Int}}) = Origin{typeof(I)}(I)
-Origin(I::Tuple{Vararg{Integer}}) = Origin(map(Int, I))
+Origin(I::Tuple{Vararg{Number}}) = Origin(map(Int, I))
 Origin(I::CartesianIndex) = Origin(Tuple(I))
-Origin(I::Integer...) = Origin(I)
+Origin(I::Number...) = Origin(I)
 # Origin(0) != Origin((0, )) but they work the same with broadcasting
-Origin(n::Integer) = Origin{Int}(Int(n))
+Origin(n::Number) = Origin{Int}(Int(n))
 
 (o::Origin)(A::AbstractArray) = o.index .- first.(axes(A))
 

--- a/test/origin.jl
+++ b/test/origin.jl
@@ -5,6 +5,15 @@ using OffsetArrays: Origin
     @test Origin(0) != Origin((0, ))
     @test Origin(CartesianIndex(1, 2)) === Origin((1, 2)) === Origin(1, 2)
 
+    @test Origin(Int32.((1,2))) == Origin(Int64.((1,2)))
+    @test Origin(Int32.((1,2))...) == Origin(Int64.((1,2))...)
+    @test Origin(Int32(1)) == Origin(Int64(1))
+
+    # 0d
+    A = OffsetArray(zeros())
+    B = OffsetArray(zeros(), Origin())
+    @test axes(A) == axes(B)
+
     # 1d
     v = [1, 2]
     @test get_origin(OffsetArray(v, Origin(2))) == (2, )
@@ -27,7 +36,7 @@ using OffsetArrays: Origin
     oa = OffsetArray(a, -3, -3, -3)
     @test get_origin(OffsetArray(oa, Origin(0))) == (0, 0, 0)
     @test get_origin(OffsetArray(oa, Origin(1, 2, 3))) == (1, 2, 3)
-    
+
     # Scalar broadcasting
     let
         a = [ [1,2,3], [4,5,6] ]

--- a/test/origin.jl
+++ b/test/origin.jl
@@ -6,8 +6,9 @@ using OffsetArrays: Origin
     @test Origin(CartesianIndex(1, 2)) === Origin((1, 2)) === Origin(1, 2)
 
     @test Origin(Int32.((1,2))) == Origin(Int64.((1,2)))
-    @test Origin(Int32.((1,2))...) == Origin(Int64.((1,2))...)
-    @test Origin(Int32(1)) == Origin(Int64(1))
+    @test Origin(Int32.((1,2))...) == Origin(Int64.((1,2))...) == Origin((1.0, 2.0))
+    @test Origin(Int32(1)) == Origin(Int64(1)) == Origin(1.0)
+    @test_throws Exception Origin(1.5)
 
     # 0d
     A = OffsetArray(zeros())


### PR DESCRIPTION
Now `Origin` accepts `Integer` arguments that may be coerced to `Int`.

After this PR:
```julia
julia> Origin(Int32(1))
Origin{Int64}(1)
```

Also disallow stuff like `Origin(("abc",))`