### PR TITLE
Convert to OffsetArrays

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -221,9 +221,7 @@ for FT in (:OffsetArray, :OffsetVector, :OffsetMatrix)
 end
 
 # conversion-related methods
-@inline OffsetArray{T}(M::AbstractArray) where {T} = OffsetArray(_of_eltype(T, M))
-@inline OffsetArray{T}(M::AbstractArray, I::Vararg) where {T} = OffsetArray{T}(M, I)
-@inline OffsetArray{T}(M::AbstractArray, I::Tuple) where {T} = OffsetArray(_of_eltype(T, M), I)
+@inline OffsetArray{T}(M::AbstractArray, I...) where {T} = OffsetArray{T,ndims(M)}(M, I...)
 
 @inline OffsetArray{T,N}(M::AbstractArray{<:Any,N}) where {T,N} = OffsetArray(_of_eltype(T, M))
 @inline OffsetArray{T,N}(M::AbstractArray{<:Any,N}, I::Vararg) where {T,N} = OffsetArray{T,N}(M, I)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -237,9 +237,9 @@ OffsetArray{T,N}(M::AbstractArray{<:Any,N}, I::NTuple{N,Any}) where {T,N} = Offs
 OffsetArray{T,N}(M::AbstractArray{<:Any,N}) where {T,N} = OffsetArray(_of_eltype(T, M))
 
 OffsetArray{T,N,A}(M::AbstractArray, I::Vararg) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(M, I)
-OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::NTuple{N,Any}) where {T,N,A<:AbstractArray{T,N}} = OffsetArray(A(M), I)
-OffsetArray{T,N,A}(M::AbstractArray) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(A(M), ntuple(zero, Val(N)))
-OffsetArray{T,N,A}(M::OffsetArray{<:Any,N}) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(A(parent(M)), M.offsets)
+OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::NTuple{N,Any}) where {T,N,A<:AbstractArray{T,N}} = OffsetArray(convert(A, M)::A, I)
+OffsetArray{T,N,A}(M::AbstractArray) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(convert(A, M)::A, ntuple(zero, Val(N)))
+OffsetArray{T,N,A}(M::OffsetArray{<:Any,N}) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(convert(A, parent(M))::A, M.offsets)
 
 Base.convert(::Type{T}, M::AbstractArray) where {T<:OffsetArray} = M isa T ? M : T(M)
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -223,9 +223,10 @@ end
 # conversion-related methods
 @inline OffsetArray{T}(M::AbstractArray, I...) where {T} = OffsetArray{T,ndims(M)}(M, I...)
 
-@inline OffsetArray{T,N}(M::AbstractArray{<:Any,N}) where {T,N} = OffsetArray(_of_eltype(T, M))
-@inline OffsetArray{T,N}(M::AbstractArray{<:Any,N}, I::Vararg) where {T,N} = OffsetArray{T,N}(M, I)
-@inline OffsetArray{T,N}(M::AbstractArray{<:Any,N}, I::Tuple) where {T,N} = OffsetArray(_of_eltype(T, M), I)
+@inline function OffsetArray{T,N}(M::AbstractArray{<:Any,N}, I...) where {T,N}
+    M2 = _of_eltype(T, M)
+    OffsetArray{T,N,typeof(M2)}(M2, I...)
+end
 
 @inline OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::Vararg) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(M, I)
 @inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::NTuple{N,Int}) where {T,N,A<:AbstractArray{T,N}}

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -449,9 +449,11 @@ end
 
 # avoid hitting the slow method getindex(::Array, ::AbstractRange{Int})
 # instead use the faster getindex(::Array, ::UnitRange{Int})
-@propagate_inbounds function Base.getindex(A::Array, r::Union{IdOffsetRange, IIUR})
-    B = A[_contiguousindexingtype(r)]
-    _maybewrapoffset(B, axes(r))
+if VERSION <= v"1.7.0-DEV.1039"
+    @propagate_inbounds function Base.getindex(A::Array, r::Union{IdOffsetRange, IIUR})
+        B = A[UnitRange(r)]
+        _maybewrapoffset(B, axes(r))
+    end
 end
 
 # Linear Indexing of OffsetArrays with AbstractUnitRanges may use the faster contiguous indexing methods

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -223,6 +223,11 @@ for FT in (:OffsetArray, :OffsetVector, :OffsetMatrix)
     @eval @inline $FT(A::AbstractArray, origin::Origin) = $FT(A, origin(A))
 end
 
+# conversion-related methods
+OffsetArray{T,N,A}(M::AbstractArray) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(A(M), ntuple(zero, Val(N)))
+OffsetArray{T,N,A}(M::OffsetArray{<:Any,N}) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(A(parent(M)), M.offsets)
+Base.convert(::Type{T}, M::AbstractArray) where {T<:OffsetArray} = M isa T ? M : T(M)
+
 # array initialization
 @inline function OffsetArray{T,N}(init::ArrayInitializer, inds::Tuple{Vararg{OffsetAxisKnownLength}}) where {T,N}
     _checkindices(N, inds, "indices")

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -451,7 +451,7 @@ end
 # instead use the faster getindex(::Array, ::UnitRange{Int})
 if VERSION <= v"1.7.0-DEV.1039"
     @propagate_inbounds function Base.getindex(A::Array, r::Union{IdOffsetRange, IIUR})
-        B = A[UnitRange(r)]
+        B = A[_contiguousindexingtype(r)]
         _maybewrapoffset(B, axes(r))
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,6 +13,8 @@ _strip_IdOffsetRange(r) = r
 _offset(axparent::AbstractUnitRange, ax::AbstractUnitRange) = first(ax) - first(axparent)
 _offset(axparent::AbstractUnitRange, ::Union{Integer, Colon}) = 1 - first(axparent)
 
+_offsets(A::AbstractArray) = map(ax -> first(ax) - 1, axes(A))
+
 """
     OffsetArrays.AxisConversionStyle(typeof(indices))
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -95,3 +95,6 @@ if VERSION <= v"1.7.0-DEV.1039"
 else
     _contiguousindexingtype(r::AbstractUnitRange{<:Integer}) = r
 end
+
+_of_eltype(::Type{T}, M::AbstractArray{T}) where {T} = M
+_of_eltype(T, M::AbstractArray) = map(T, M)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2193,6 +2193,15 @@ end
     b2 = OffsetArray{Float64, 1, typeof(a)}(a, (-big(1),))
     @test b1 == b2
 
+    # test for custom offset arrays
+    a = ZeroBasedRange(1:3)
+    b = OffsetVector{Float64, UnitRange{Float64}}(a)
+    @test b isa OffsetVector{Float64, UnitRange{Float64}}
+    @test b == a
+    b = OffsetVector{Int, Vector{Int}}(a)
+    @test b isa OffsetVector{Int, Vector{Int}}
+    @test b == a
+
     # changing the number of dimensions is not permitted
     A = rand(2,2)
     @test_throws MethodError convert(OffsetArray{Float64, 3}, A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -280,7 +280,7 @@ struct WeirdInteger{T} <: Integer
     x :: T
 end
 # assume that it doesn't behave as expected
-Base.convert(::Type{Int}, a::WeirdInteger) = a
+Base.Int(a::WeirdInteger) = a
 
 @testset "Constructors" begin
     @testset "Single-entry arrays in dims 0:5" begin
@@ -2163,6 +2163,8 @@ end
             b = T(a2, 0, 0)
             @test b isa T
             @test b == a2
+            b = T(a2, 1, 1)
+            @test axes(b) == map((x,y) -> x .+ y, axes(a2), (1,1))
             b = T(a2)
             @test b isa T
             @test b == a2
@@ -2172,6 +2174,8 @@ end
             b = T(a2, 0, 0, 0)
             @test b isa T
             @test b == a2
+            b = T(a2, 1, 1, 1)
+            @test axes(b) == map((x,y) -> x .+ y, axes(a2), (1,1,1))
             b = T(a2)
             @test b isa T
             @test b == a2
@@ -2183,6 +2187,16 @@ end
     @test a === b
     b = convert(OffsetVector, a)
     @test a === b
+
+    # test that non-Int offsets work correctly if the parent is an OffsetArray
+    b1 = OffsetArray{Float64, 1, typeof(a)}(a, (-1,))
+    b2 = OffsetArray{Float64, 1, typeof(a)}(a, (-big(1),))
+    @test b1 == b2
+
+    # changing the number of dimensions is not permitted
+    A = rand(2,2)
+    @test_throws MethodError convert(OffsetArray{Float64, 3}, A)
+    @test_throws MethodError convert(OffsetArray{Float64, 3, Array{Float64,3}}, A)
 end
 
 include("origin.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2131,6 +2131,12 @@ end
     oa = [OffsetArray(ai, 0, 0) for ai in a]
     b = ones(2,2)
     @test b * a == b * oa
+
+    a = ones(2:3)
+    b = convert(OffsetArray, a)
+    @test a === b
+    b = convert(OffsetVector, a)
+    @test a === b
 end
 
 include("origin.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2132,6 +2132,52 @@ end
     b = ones(2,2)
     @test b * a == b * oa
 
+    for a = [1:4, ones(1:5)]
+        @test convert(OffsetArray, a) isa OffsetArray
+        @test convert(OffsetArray, a) == a
+        @test convert(OffsetArray{eltype(a)}, a) isa OffsetArray{eltype(a)}
+        @test convert(OffsetArray{eltype(a)}, a) == a
+        @test convert(OffsetArray{Float32}, a) isa OffsetArray{Float32}
+        @test convert(OffsetArray{Float32}, a) == a
+        @test convert(OffsetArray{eltype(a),1}, a) isa OffsetArray{eltype(a),1}
+        @test convert(OffsetArray{eltype(a),1}, a) == a
+        @test convert(OffsetArray{Float32,1}, a) isa OffsetArray{Float32,1}
+        @test convert(OffsetArray{Float32,1}, a) == a
+        @test convert(OffsetVector, a) isa OffsetVector
+        @test convert(OffsetVector, a) == a
+        @test convert(OffsetVector{Float32}, a) isa OffsetVector{Float32}
+        @test convert(OffsetVector{Float32}, a) == a
+
+        for T in [OffsetArray{Float32}, OffsetArray{Float32, 1}, OffsetArray{Float32, 1, Vector{Float32}},
+            OffsetVector{Float32}, OffsetVector{Float32, Vector{Float32}}]
+            b = T(a, 0)
+            @test b isa T
+            @test b == a
+            b = T(a)
+            @test b isa T
+            @test b == a
+        end
+        a2 = reshape(a, :, 1)
+        for T in [OffsetArray{Float32}, OffsetArray{Float32, 2}, OffsetArray{Float32, 2, Matrix{Float32}},
+            OffsetMatrix{Float32}, OffsetMatrix{Float32, Matrix{Float32}}]
+            b = T(a2, 0, 0)
+            @test b isa T
+            @test b == a2
+            b = T(a2)
+            @test b isa T
+            @test b == a2
+        end
+        a2 = reshape(a, :, 1, 1)
+        for T in [OffsetArray{Float32}, OffsetArray{Float32, 3}, OffsetArray{Float32, 3, Array{Float32,3}}]
+            b = T(a2, 0, 0, 0)
+            @test b isa T
+            @test b == a2
+            b = T(a2)
+            @test b isa T
+            @test b == a2
+        end
+    end
+
     a = ones(2:3)
     b = convert(OffsetArray, a)
     @test a === b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2238,7 +2238,7 @@ end
 
     # test using custom indices
     a = ones(2,2)
-    for T in [OffsetMatrix{Float64}, OffsetMatrix{Float64, Matrix{Float64}},
+    for T in [OffsetMatrix{Int}, OffsetMatrix{Float64}, OffsetMatrix{Float64, Matrix{Float64}},
         OffsetMatrix{Int, Matrix{Int}}]
 
         b = T(a, ZeroBasedIndexing())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2236,6 +2236,16 @@ end
         @test c == a
     end
 
+    # test using custom indices
+    a = ones(2,2)
+    for T in [OffsetMatrix{Float64}, OffsetMatrix{Float64, Matrix{Float64}},
+        OffsetMatrix{Int, Matrix{Int}}]
+
+        b = T(a, ZeroBasedIndexing())
+        @test b isa T
+        @test axes(b) == (0:1, 0:1)
+    end
+
     # changing the number of dimensions is not permitted
     A = rand(2,2)
     @test_throws MethodError convert(OffsetArray{Float64, 3}, A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2104,4 +2104,33 @@ end
     end
 end
 
+# issue 171
+struct Foo2
+    o::OffsetArray{Float64,1,Array{Float64,1}}
+end
+
+@testset "convert" begin
+    d = Diagonal([1,1,1])
+    M = convert(Matrix{Float64}, d)
+    od = OffsetArray(d, 1, 1)
+    oM = convert(OffsetMatrix{Float64, Matrix{Float64}}, od)
+    @test eltype(oM) == Float64
+    @test typeof(parent(oM)) == Matrix{Float64}
+    @test oM == od
+    oM2 = convert(OffsetMatrix{Float64, Matrix{Float64}}, d)
+    @test eltype(oM2) == Float64
+    @test typeof(parent(oM2)) == Matrix{Float64}
+    @test oM2 == d
+
+    # issue 171
+    O = zeros(Int, 0:2)
+    F = Foo2(O)
+    @test F.o == O
+
+    a = [MMatrix{2,2}(1:4) for i = 1:2]
+    oa = [OffsetArray(ai, 0, 0) for ai in a]
+    b = ones(2,2)
+    @test b * a == b * oa
+end
+
 include("origin.jl")


### PR DESCRIPTION
Fixes #171 ~partly~

Now conversion works if the `OffsetArray` type is fully specified (~doesn't work at present if it's left as a `UnionAll`~ works now).

```julia
julia> d = Diagonal([1,1,1])
3×3 Diagonal{Int64, Vector{Int64}}:
 1  ⋅  ⋅
 ⋅  1  ⋅
 ⋅  ⋅  1

julia> convert(OffsetMatrix{Float64, Matrix{Float64}}, d)
3×3 OffsetArray(::Matrix{Float64}, 1:3, 1:3) with eltype Float64 with indices 1:3×1:3:
 1.0  0.0  0.0
 0.0  1.0  0.0
 0.0  0.0  1.0

julia> convert(OffsetMatrix{Float32, Matrix{Float32}}, d)
3×3 OffsetArray(::Matrix{Float32}, 1:3, 1:3) with eltype Float32 with indices 1:3×1:3:
 1.0  0.0  0.0
 0.0  1.0  0.0
 0.0  0.0  1.0

julia> convert(OffsetMatrix{Float32, Matrix{Float32}}, OffsetArray(d, 2, 2))
3×3 OffsetArray(::Matrix{Float32}, 3:5, 3:5) with eltype Float32 with indices 3:5×3:5:
 1.0  0.0  0.0
 0.0  1.0  0.0
 0.0  0.0  1.0
```

As a consequence this matrix vector product works now (used to error earlier):

```julia
julia> a = [MMatrix{2,2}(1:4) for i = 1:2];

julia> oa = [OffsetArray(ai, 0, 0) for ai in a];

julia> b = ones(2,2);

julia> b * oa
2-element Vector{OffsetMatrix{Float64, SizedMatrix{2, 2, Float64, 2, Matrix{Float64}}}}:
 [2.0 6.0; 4.0 8.0]
 [2.0 6.0; 4.0 8.0]
```

These constructors create copies if necessary.

~I have not added the other `UnionAll` constructors deliberately as it'll not be clear if the `OffsetArray(::AbstractArray)` constructor creates a copy or not. Currently it doesn't create a copy for `OffsetArray(::Array{T,0})`, so creating a copy for other arrays might be confusing. On the other hand, we may choose to not create a copy at all, which will make the `OffsetArray` constructor behave differently from `Array`~.