### PR TITLE
Specialize map for eltype conversion

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -512,6 +512,10 @@ for OR in [:IIUR, :IdOffsetRange]
     end
 end
 
+# eltype conversion
+# This may use specialized map methods for the parent
+Base.map(::Type{T}, O::OffsetArray) where {T} = OffsetArray(map(T, parent(O)), O.offsets)
+
 # mapreduce is faster with an IdOffsetRange than with an OffsetUnitRange
 # We therefore convert OffsetUnitRanges to IdOffsetRanges with the same values and axes
 function Base.mapreduce(f, op, As::OffsetUnitRange{<:Integer}...; kw...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,11 +78,6 @@ for Z in [:ZeroBasedRange, :ZeroBasedUnitRange]
     end
 end
 
-Base.@propagate_inbounds function Base.getindex(A::Array, r::ZeroBasedUnitRange)
-    B = A[parent(r)]
-    OffsetArrays._maybewrapoffset(B, axes(r))
-end
-
 function same_value(r1, r2)
     length(r1) == length(r2) || return false
     for (v1, v2) in zip(r1, r2)
@@ -780,6 +775,13 @@ end
     B = BidirectionalVector([1, 2, 3], -2)
     A = OffsetArray(B, -1:1)
     @test axes(A) == (IdentityUnitRange(-1:1),)
+end
+
+@testset "unwrap" begin
+    for A in [ones(2, 2), ones(2:3, 2:3), ZeroBasedRange(1:4)]
+        p, f = OffsetArrays.unwrap(A)
+        @test f(map(y -> y^2, p)) == A.^2
+    end
 end
 
 @testset "Traits" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1750,6 +1750,14 @@ end
     @test dest[1,7] == 2
     @test dest[1,8] == 4
     @test dest[1,9] == -2
+
+    @testset "eltype conversion" begin
+        a = OffsetArray(1:2, 1)
+        b = map(BigInt, a)
+        @test eltype(b) == BigInt
+        @test b == a
+        @test b isa OffsetArrays.OffsetRange
+    end
 end
 
 @testset "reductions" begin


### PR DESCRIPTION
This PR passes on `eltype` conversions to the parent array, which may use specialized methods if these are defined.

Before
```julia
julia> map(Int, OffsetArray(1:10, 2))
10-element OffsetArray(::Vector{Int64}, 3:12) with eltype Int64 with indices 3:12:
  1
  2
  3
  4
  5
  6
  7
  8
  9
 10
```

After this PR:
```julia
julia> map(Int, OffsetArray(1:10, 2))
1:10 with indices 3:12
```