### PR TITLE
fix for Iterators.partition on IdOffsetRange

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -195,7 +195,7 @@ end
 @inline function Base.iterate(itr::Iterators.PartitionIterator{<:IdOffsetRange}, (s, e))
     s > e && return nothing
     r = min(s + itr.n - 1, e)
-    return @inbounds itr.c[s:r], (r + 1, e)
+    return @inbounds view(itr.c,s:r), (r + 1, e) # use view here, to keep consistancy
 end
 
 @inline function Base.getindex(r::IdOffsetRange, i::Integer)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -188,6 +188,15 @@ end
     ret === nothing && return nothing
     return (eltype(r)(ret[1] + r.offset), ret[2])
 end
+@inline function Base.iterate(itr::Iterators.PartitionIterator{<:IdOffsetRange})
+    ax = eachindex(itr.c)
+    iterate(itr, (first(ax), last(ax)))
+end
+@inline function Base.iterate(itr::Iterators.PartitionIterator{<:IdOffsetRange}, (s, e))
+    s > e && return nothing
+    r = min(s + itr.n - 1, e)
+    return @inbounds itr.c[s:r], (r + 1, e)
+end
 
 @inline function Base.getindex(r::IdOffsetRange, i::Integer)
     i isa Bool && throw(ArgumentError("invalid index: $i of type Bool"))


### PR DESCRIPTION
before
```julia
Iterators.partition(IdOffsetRange(500:1001,10000),500)|> collect
2-element Vector{UnitRange{Int64}}:
 500:999
 1000:1001
```
after
```julia
Iterators.partition(IdOffsetRange(500:1001,10000),500)|> collect
2-element Vector{UnitRange{Int64}}:
 10500:10999
 11000:11001
```