### PR TITLE
Fix Int overflow bugs in offset computation

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -19,11 +19,6 @@ const OffsetAxisKnownLength = Union{Integer, AbstractUnitRange}
 const OffsetAxis = Union{OffsetAxisKnownLength, Colon}
 const ArrayInitializer = Union{UndefInitializer, Missing, Nothing}
 
-struct SkipOverflowCheck{N,T<:NTuple{N,Integer}}
-    offsets :: T
-end
-Base.map(f, S::SkipOverflowCheck) = SkipOverflowCheck(map(f, S.offsets))
-
 ## OffsetArray
 """
     OffsetArray(A, indices...)
@@ -115,13 +110,10 @@ julia> OffsetArray(a, OffsetArrays.Origin(0)) # set the origin to zero along eac
 struct OffsetArray{T,N,AA<:AbstractArray{T,N}} <: AbstractArray{T,N}
     parent::AA
     offsets::NTuple{N,Int}
-    @inline function OffsetArray{T, N, AA}(parent::AA, offsets::NTuple{N, Int}) where {T, N, AA<:AbstractArray{T,N}}
+    @inline function OffsetArray{T, N, AA}(parent::AA, offsets::NTuple{N, Int}; checkoverflow = true) where {T, N, AA<:AbstractArray{T,N}}
         # allocation of `map` on tuple is optimized away
-        map(overflow_check, axes(parent), offsets)
+        checkoverflow && map(overflow_check, axes(parent), offsets)
         new{T, N, AA}(parent, offsets)
-    end
-    @inline function OffsetArray{T, N, AA}(parent::AA, S::SkipOverflowCheck{N, NTuple{N,Int}}) where {T, N, AA<:AbstractArray{T,N}}
-        new{T, N, AA}(parent, S.offsets)
     end
 end
 
@@ -160,26 +152,20 @@ end
 
 # Tuples of integers are treated as offsets
 # Empty Tuples are handled here
-@inline function OffsetArray(A::AbstractArray, offsets::Tuple{Vararg{Integer}})
+@inline function OffsetArray(A::AbstractArray, offsets::Tuple{Vararg{Integer}}; kw...)
     _checkindices(A, offsets, "offsets")
-    OffsetArray{eltype(A), ndims(A), typeof(A)}(A, offsets)
-end
-@inline function OffsetArray(A::AbstractArray{<:Any,N}, offsets::SkipOverflowCheck{N}) where {N}
-    OffsetArray{eltype(A), N, typeof(A)}(A, map(Int, offsets)::SkipOverflowCheck{N,NTuple{N,Int}})
+    OffsetArray{eltype(A), ndims(A), typeof(A)}(A, offsets; kw...)
 end
 
 # These methods are necessary to disallow incompatible dimensions for
 # the OffsetVector and the OffsetMatrix constructors
 for (FT, ND) in ((:OffsetVector, :1), (:OffsetMatrix, :2))
-    @eval @inline function $FT(A::AbstractArray{<:Any,$ND}, offsets::Tuple{Vararg{Integer}})
+    @eval @inline function $FT(A::AbstractArray{<:Any,$ND}, offsets::Tuple{Vararg{Integer}}; kw...)
         _checkindices(A, offsets, "offsets")
-        OffsetArray{eltype(A), $ND, typeof(A)}(A, offsets)
-    end
-    @eval @inline function $FT(A::AbstractArray{<:Any,$ND}, offsets::SkipOverflowCheck{$ND})
-        OffsetArray{eltype(A), $ND, typeof(A)}(A, map(Int, offsets)::SkipOverflowCheck{$ND,NTuple{$ND,Int}})
+        OffsetArray{eltype(A), $ND, typeof(A)}(A, offsets; kw...)
     end
     FTstr = string(FT)
-    @eval @inline function $FT(A::AbstractArray, offsets::Tuple{Vararg{Integer}})
+    @eval @inline function $FT(A::AbstractArray, offsets::Tuple{Vararg{Integer}}; kw...)
         throw(ArgumentError($FTstr*" requires a "*string($ND)*"D array"))
     end
 end
@@ -188,98 +174,98 @@ end
 for FT in (:OffsetArray, :OffsetVector, :OffsetMatrix)
     # Nested OffsetArrays may strip off the wrapper and collate the offsets
     # empty tuples are handled here
-    @eval @inline function $FT(A::OffsetArray, offsets::Tuple{Vararg{Int}})
+    @eval @inline function $FT(A::OffsetArray, offsets::Tuple{Vararg{Int}}; checkoverflow = true)
         _checkindices(A, offsets, "offsets")
         # ensure that the offsets may be added together without an overflow
-        map(overflow_check, axes(A), offsets)
+        checkoverflow && map(overflow_check, axes(A), offsets)
         I = map(+, _offsets(A, parent(A)), offsets)
-        $FT(parent(A), SkipOverflowCheck(I))
+        $FT(parent(A), I, checkoverflow = false)
     end
-    @eval @inline function $FT(A::OffsetArray, offsets::Tuple{Integer,Vararg{Integer}})
-        $FT(A, map(Int, offsets))
+    @eval @inline function $FT(A::OffsetArray, offsets::Tuple{Integer,Vararg{Integer}}; kw...)
+        $FT(A, map(Int, offsets); kw...)
     end
 
     # In general, indices get converted to AbstractUnitRanges.
     # CartesianIndices{N} get converted to N ranges
-    @eval @inline function $FT(A::AbstractArray, inds::Tuple{Any,Vararg{Any}})
-        $FT(A, _toAbstractUnitRanges(to_indices(A, axes(A), inds)))
+    @eval @inline function $FT(A::AbstractArray, inds::Tuple{Any,Vararg{Any}}; kw...)
+        $FT(A, _toAbstractUnitRanges(to_indices(A, axes(A), inds)); kw...)
     end
 
     # convert ranges to offsets
-    @eval @inline function $FT(A::AbstractArray, inds::Tuple{AbstractUnitRange,Vararg{AbstractUnitRange}})
+    @eval @inline function $FT(A::AbstractArray, inds::Tuple{AbstractUnitRange,Vararg{AbstractUnitRange}}; kw...)
         _checkindices(A, inds, "indices")
         # Performance gain by wrapping the error in a function: see https://github.com/JuliaLang/julia/issues/37558
         throw_dimerr(lA, lI) = throw(DimensionMismatch("supplied axes do not agree with the size of the array (got size $lA for the array and $lI for the indices"))
         lA = size(A)
         lI = map(length, inds)
         lA == lI || throw_dimerr(lA, lI)
-        $FT(A, map(_offset, axes(A), inds))
+        $FT(A, map(_offset, axes(A), inds); kw...)
     end
 
-    @eval @inline $FT(A::AbstractArray, inds::Vararg) = $FT(A, inds)
-    @eval @inline $FT(A::AbstractArray) = $FT(A, ntuple(zero, Val(ndims(A))))
+    @eval @inline $FT(A::AbstractArray, inds::Vararg; kw...) = $FT(A, inds; kw...)
+    @eval @inline $FT(A::AbstractArray; checkoverflow = false) = $FT(A, ntuple(zero, Val(ndims(A))), checkoverflow = checkoverflow)
 
-    @eval @inline $FT(A::AbstractArray, origin::Origin) = $FT(A, origin(A))
+    @eval @inline $FT(A::AbstractArray, origin::Origin; checkoverflow = false) = $FT(A, origin(A); checkoverflow = checkoverflow)
 end
 
 # conversion-related methods
-@inline OffsetArray{T}(M::AbstractArray, I...) where {T} = OffsetArray{T,ndims(M)}(M, I...)
+@inline OffsetArray{T}(M::AbstractArray, I...; kw...) where {T} = OffsetArray{T,ndims(M)}(M, I...; kw...)
 
-@inline function OffsetArray{T,N}(M::AbstractArray{<:Any,N}, I...) where {T,N}
+@inline function OffsetArray{T,N}(M::AbstractArray{<:Any,N}, I...; kw...) where {T,N}
     M2 = _of_eltype(T, M)
-    OffsetArray{T,N}(M2, I...)
+    OffsetArray{T,N}(M2, I...; kw...)
 end
-@inline OffsetArray{T,N}(M::OffsetArray{T,N}, I...) where {T,N} = OffsetArray(M, I...)
-@inline OffsetArray{T,N}(M::AbstractArray{T,N}, I...) where {T,N} = OffsetArray{T,N,typeof(M)}(M, I...)
+@inline OffsetArray{T,N}(M::OffsetArray{T,N}, I...; kw...) where {T,N} = OffsetArray(M, I...; kw...)
+@inline OffsetArray{T,N}(M::AbstractArray{T,N}, I...; kw...) where {T,N} = OffsetArray{T,N,typeof(M)}(M, I...; kw...)
 
-@inline OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::Vararg) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(M, I)
-@inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::NTuple{N,Int}) where {T,N,A<:AbstractArray{T,N}}
-    map(overflow_check, axes(M), I)
+@inline OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::Vararg; kw...) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(M, I; kw...)
+@inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::NTuple{N,Int}; checkoverflow = true) where {T,N,A<:AbstractArray{T,N}}
+    checkoverflow && map(overflow_check, axes(M), I)
     Mv = no_offset_view(M)
     MvA = convert(A, Mv)::A
     Iof = map(+, _offsets(M), I)
-    OffsetArray{T,N,A}(MvA, map(Int, SkipOverflowCheck(Iof))::SkipOverflowCheck{N,NTuple{N,Int}})
+    OffsetArray{T,N,A}(MvA, Iof, checkoverflow = false)
 end
-@inline function OffsetArray{T, N, AA}(parent::AbstractArray{<:Any,N}, offsets::NTuple{N, Integer}) where {T, N, AA<:AbstractArray{T,N}}
-    OffsetArray{T, N, AA}(parent, map(Int, offsets)::NTuple{N,Int})
+@inline function OffsetArray{T, N, AA}(parent::AbstractArray{<:Any,N}, offsets::NTuple{N, Integer}; kw...) where {T, N, AA<:AbstractArray{T,N}}
+    OffsetArray{T, N, AA}(parent, map(Int, offsets)::NTuple{N,Int}; kw...)
 end
-@inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::Tuple{AbstractUnitRange,Vararg{AbstractUnitRange}}) where {T,N,A<:AbstractArray{T,N}}
+@inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::Tuple{AbstractUnitRange,Vararg{AbstractUnitRange}}; kw...) where {T,N,A<:AbstractArray{T,N}}
     _checkindices(M, I, "indices")
     # Performance gain by wrapping the error in a function: see https://github.com/JuliaLang/julia/issues/37558
     throw_dimerr(lA, lI) = throw(DimensionMismatch("supplied axes do not agree with the size of the array (got size $lA for the array and $lI for the indices"))
     lM = size(M)
     lI = map(length, I)
     lM == lI || throw_dimerr(lM, lI)
-    OffsetArray{T,N,A}(M, map(_offset, axes(M), I))
+    OffsetArray{T,N,A}(M, map(_offset, axes(M), I); kw...)
 end
-@inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::Tuple) where {T,N,A<:AbstractArray{T,N}}
-    OffsetArray{T,N,A}(M, _toAbstractUnitRanges(to_indices(M, axes(M), I)))
+@inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::Tuple; kw...) where {T,N,A<:AbstractArray{T,N}}
+    OffsetArray{T,N,A}(M, _toAbstractUnitRanges(to_indices(M, axes(M), I)); kw...)
 end
-@inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}) where {T,N,A<:AbstractArray{T,N}}
+@inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}; kw...) where {T,N,A<:AbstractArray{T,N}}
     Mv = no_offset_view(M)
     MvA = convert(A, Mv)::A
-    OffsetArray{T,N,A}(MvA, _offsets(M))
+    OffsetArray{T,N,A}(MvA, _offsets(M); kw...)
 end
-@inline OffsetArray{T,N,A}(M::A) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(M, ntuple(zero, Val(N)))
+@inline OffsetArray{T,N,A}(M::A; checkoverflow = false) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(M, ntuple(zero, Val(N)); checkoverflow = checkoverflow)
 
 Base.convert(::Type{T}, M::AbstractArray) where {T<:OffsetArray} = M isa T ? M : T(M)
 
 # array initialization
-@inline function OffsetArray{T,N}(init::ArrayInitializer, inds::Tuple{Vararg{OffsetAxisKnownLength}}) where {T,N}
+@inline function OffsetArray{T,N}(init::ArrayInitializer, inds::Tuple{Vararg{OffsetAxisKnownLength}}; kw...) where {T,N}
     _checkindices(N, inds, "indices")
     AA = Array{T,N}(init, map(_indexlength, inds))
-    OffsetArray{T, N, typeof(AA)}(AA, map(_indexoffset, inds))
+    OffsetArray{T, N, typeof(AA)}(AA, map(_indexoffset, inds); kw...)
 end
-@inline function OffsetArray{T, N}(init::ArrayInitializer, inds::Tuple) where {T, N}
-    OffsetArray{T, N}(init, _toAbstractUnitRanges(inds))
+@inline function OffsetArray{T, N}(init::ArrayInitializer, inds::Tuple; kw...) where {T, N}
+    OffsetArray{T, N}(init, _toAbstractUnitRanges(inds); kw...)
 end
-@inline OffsetArray{T,N}(init::ArrayInitializer, inds::Vararg) where {T,N} = OffsetArray{T,N}(init, inds)
+@inline OffsetArray{T,N}(init::ArrayInitializer, inds::Vararg; kw...) where {T,N} = OffsetArray{T,N}(init, inds; kw...)
 
-@inline OffsetArray{T}(init::ArrayInitializer, inds::NTuple{N, OffsetAxisKnownLength}) where {T,N} = OffsetArray{T,N}(init, inds)
-@inline function OffsetArray{T}(init::ArrayInitializer, inds::Tuple) where {T}
-    OffsetArray{T}(init, _toAbstractUnitRanges(inds))
+@inline OffsetArray{T}(init::ArrayInitializer, inds::NTuple{N, OffsetAxisKnownLength}; kw...) where {T,N} = OffsetArray{T,N}(init, inds; kw...)
+@inline function OffsetArray{T}(init::ArrayInitializer, inds::Tuple; kw...) where {T}
+    OffsetArray{T}(init, _toAbstractUnitRanges(inds); kw...)
 end
-@inline OffsetArray{T}(init::ArrayInitializer, inds::Vararg) where {T} = OffsetArray{T}(init, inds)
+@inline OffsetArray{T}(init::ArrayInitializer, inds::Vararg; kw...) where {T} = OffsetArray{T}(init, inds; kw...)
 
 Base.IndexStyle(::Type{OA}) where {OA<:OffsetArray} = IndexStyle(parenttype(OA))
 parenttype(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA
@@ -312,7 +298,7 @@ end
 
 # Utils to translate a function to the parent while preserving offsets
 unwrap(x) = x, identity
-unwrap(x::OffsetArray) = parent(x), data -> OffsetArray(data, x.offsets)
+unwrap(x::OffsetArray) = parent(x), data -> OffsetArray(data, x.offsets, checkoverflow = false)
 function parent_call(f, x)
     parent, wrap_offset = unwrap(x)
     wrap_offset(f(parent))
@@ -465,7 +451,7 @@ end
 # An OffsetUnitRange might use the rapid getindex(::Array, ::AbstractUnitRange{Int}) for contiguous indexing
 @propagate_inbounds function Base.getindex(A::Array, r::OffsetUnitRange{Int})
     B = A[_contiguousindexingtype(parent(r))]
-    OffsetArray(B, axes(r))
+    OffsetArray(B, axes(r), checkoverflow = false)
 end
 
 # avoid hitting the slow method getindex(::Array, ::AbstractRange{Int})

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -205,7 +205,7 @@ for FT in (:OffsetArray, :OffsetVector, :OffsetMatrix)
     @eval @inline $FT(A::AbstractArray, inds::Vararg; kw...) = $FT(A, inds; kw...)
     @eval @inline $FT(A::AbstractArray; checkoverflow = false) = $FT(A, ntuple(zero, Val(ndims(A))), checkoverflow = checkoverflow)
 
-    @eval @inline $FT(A::AbstractArray, origin::Origin; checkoverflow = false) = $FT(A, origin(A); checkoverflow = checkoverflow)
+    @eval @inline $FT(A::AbstractArray, origin::Origin; checkoverflow = true) = $FT(A, origin(A); checkoverflow = checkoverflow)
 end
 
 # conversion-related methods

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -14,6 +14,7 @@ _offset(axparent::AbstractUnitRange, ax::AbstractUnitRange) = first(ax) - first(
 _offset(axparent::AbstractUnitRange, ::Union{Integer, Colon}) = 1 - first(axparent)
 
 _offsets(A::AbstractArray) = map(ax -> first(ax) - 1, axes(A))
+_offsets(A::AbstractArray, B::AbstractArray) = map(_offset, axes(B), axes(A))
 
 """
     OffsetArrays.AxisConversionStyle(typeof(indices))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -537,12 +537,18 @@ Base.Int(a::WeirdInteger) = a
         @test axes(OffsetVector(v, typemax(Int)-length(v))) == (IdOffsetRange(axes(v)[1], typemax(Int)-length(v)), )
         @test_throws OverflowError OffsetVector(v, typemax(Int)-length(v)+1)
         ao = OffsetArray(v, typemin(Int))
-        @test_nowarn OffsetArray{Float64, 1, typeof(ao)}(ao, (-1, ))
+        ao2 = OffsetArray{Float64, 1, typeof(ao)}(ao, (-1, ))
+        @test axes(ao2, 1) == typemin(Int) .+ (0:length(v)-1)
+        ao2 = OffsetArray(ao, (-1,))
+        @test axes(ao2, 1) == typemin(Int) .+ (0:length(v)-1)
         @test_throws OverflowError OffsetArray{Float64, 1, typeof(ao)}(ao, (-2, )) # inner Constructor
         @test_throws OverflowError OffsetArray(ao, (-2, )) # convinient constructor accumulate offsets
         @test_throws OverflowError OffsetVector(1:0, typemax(Int))
         @test_throws OverflowError OffsetVector(OffsetVector(1:0, 0), typemax(Int))
         @test_throws OverflowError OffsetArray(zeros(Int, typemax(Int):typemax(Int)), 2)
+
+        b = OffsetArray(OffsetArray(big(1):2, 1), typemax(Int)-1)
+        @test axes(b, 1) == big(typemax(Int)) .+ (1:2)
 
         @testset "OffsetRange" begin
             for r in Any[1:100, big(1):big(2)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1888,10 +1888,10 @@ end
         b = map(BigInt, a)
         @test eltype(b) == BigInt
         @test b == a
-        @test b isa OffsetArrays.OffsetRange
+        @test parent(b) isa AbstractRange
 
         for ri in Any[2:3, Base.OneTo(2)]
-            for r in [IdentityUnitRange(ri), IdOffsetRange(ri), IdOffsetRange(ri, 1)]
+            for r in [IdentityUnitRange(ri), IdOffsetRange(ri), IdOffsetRange(ri, 1), OffsetArray(ri), OffsetArray(ri, 2)]
                 for T in [Int8, Int16, Int32, Int64, Int128, BigInt, Float32, Float64, BigFloat]
                     r2 = map(T, r)
                     @test eltype(r2) == T
@@ -1903,7 +1903,7 @@ end
 
         @testset "Bool" begin
             for ri in Any[0:0, 0:1, 1:0, 1:1, Base.OneTo(0), Base.OneTo(1)]
-                for r = Any[IdentityUnitRange(ri), IdOffsetRange(ri), IdOffsetRange(ri .- 1, 1)]
+                for r = Any[IdentityUnitRange(ri), IdOffsetRange(ri), IdOffsetRange(ri .- 1, 1), OffsetVector(ri)]
                     r2 = map(Bool, r)
                     @test eltype(r2) == Bool
                     @test axes(r2) == axes(r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -546,6 +546,7 @@ Base.Int(a::WeirdInteger) = a
         @test_throws OverflowError OffsetVector(1:0, typemax(Int))
         @test_throws OverflowError OffsetVector(OffsetVector(1:0, 0), typemax(Int))
         @test_throws OverflowError OffsetArray(zeros(Int, typemax(Int):typemax(Int)), 2)
+        @test_throws OverflowError OffsetArray(v, OffsetArrays.Origin(typemax(Int)))
 
         b = OffsetArray(OffsetArray(big(1):2, 1), typemax(Int)-1)
         @test axes(b, 1) == big(typemax(Int)) .+ (1:2)


### PR DESCRIPTION
Related to #234 , this fixes a bug in the constructor that used to arise from an overflow in summing the offsets

On master:
```julia
julia> OffsetArray(OffsetArray(1:2, -1), typemin(Int))
ERROR: OverflowError: offset should be >= -9223372036854775807 given a pre-existing offset of -1, received an offset -9223372036854775808
```

After this PR
```julia
julia> OffsetArray(OffsetArray(1:2, -1), typemin(Int))
1:2 with indices -9223372036854775808:-9223372036854775807
```

The nested `OffsetArray` constructor is also somewhat faster now as it performs one overflow check instead of two.

On master:
```julia
julia> @btime OffsetArray($(ones(4:5)), $((2,)));
  8.313 ns (0 allocations: 0 bytes)
```

After this PR:
```julia
julia> @btime OffsetArray($(ones(4:5)), $((2,)));
  6.906 ns (0 allocations: 0 bytes)
``` 

Also fix the issue with nested `OffsetArray`s described in #234. Now

```julia
julia> A = OffsetArray(1:2, 3:4)
1:2 with indices 3:4

julia> OffsetArray{Float64}(A)
1.0:1.0:2.0 with indices 3:4
```