### PR TITLE
specialize zero and fill!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Adapt = "2, 3"
 Aqua = "0.5"
 CatIndices = "0.2"
+DistributedArrays = "0.6"
 Documenter = "0.26"
 EllipsisNotation = "1"
 FillArrays = "0.11"
@@ -19,6 +20,7 @@ julia = "0.7, 1"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+DistributedArrays = "aaf54ef3-cdf8-58ed-94cc-d582ad619b94"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
@@ -27,4 +29,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "CatIndices", "DelimitedFiles", "Documenter", "Test", "LinearAlgebra", "EllipsisNotation", "StaticArrays", "FillArrays"]
+test = ["Aqua", "CatIndices", "DistributedArrays", "DelimitedFiles", "Documenter", "Test", "LinearAlgebra", "EllipsisNotation", "StaticArrays", "FillArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.8.0"
+version = "1.8.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.8.1"
+version = "1.9.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -375,6 +375,9 @@ Base.trues(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
 Base.falses(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
     fill!(similar(BitArray, inds), false)
 
+Base.zero(A::OffsetArray) = parent_call(zero, A)
+Base.fill!(A::OffsetArray, x) = parent_call(Ap -> fill!(Ap, x), A)
+
 ## Indexing
 
 # Note this gets the index of the parent *array*, not the index of the parent *range*

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using EllipsisNotation
 using Adapt
 using StaticArrays
 using FillArrays
+using DistributedArrays
 
 DocMeta.setdocmeta!(OffsetArrays, :DocTestSetup, :(using OffsetArrays); recursive=true)
 
@@ -2037,6 +2038,18 @@ end
     B = fill(5, 3, -1:1)
     @test axes(B) == (1:3,-1:1)
     @test all(B.==5)
+
+    @testset "fill!" begin
+        D = dzeros((2,2))
+        DO = OffsetArray(D, 2, 2)
+        fill!(DO, 1)
+        @test all(isequal(1), DO)
+        @test all(iszero, zero(DO))
+
+        S = SVector{2,Int}(1,1)
+        SO = OffsetVector(S, -1)
+        @test zero(SO) isa typeof(SO)
+    end
 end
 
 @testset "broadcasting" begin


### PR DESCRIPTION
This PR does two things:

1. specialize `fill!`: This helps with special parent array types such as `DistirbutedArray` that use a customized `fill!` implementation. `OffsetArrays` may defer the `fill!` operation to the parent in general. This used to error or master.
```julia
julia> D = dzeros((2,2))
2×2 DArray{Float64, 2, Matrix{Float64}}:
 0.0  0.0
 0.0  0.0

julia> zero(D)
2×2 DArray{Float64, 2, Matrix{Float64}}:
 0.0  0.0
 0.0  0.0

julia> OD = OffsetArray(D)
2×2 OffsetArray(::DArray{Float64, 2, Matrix{Float64}}, 1:2, 1:2) with eltype Float64 with indices 1:2×1:2:
 0.0  0.0
 0.0  0.0

julia> fill!(OD, 2)
ERROR: setindex! not defined for DArray{Float64, 2, Matrix{Float64}}
Stacktrace:
 [1] error(::String, ::Type)
   @ Base ./error.jl:42
 [2] error_if_canonical_setindex(::IndexCartesian, ::DArray{Float64, 2, Matrix{Float64}}, ::Int64, ::Int64)
   @ Base ./abstractarray.jl:1277
 [3] setindex!
   @ ./abstractarray.jl:1266 [inlined]
 [4] setindex!
   @ ~/Dropbox/JuliaPackages/OffsetArrays.jl/src/OffsetArrays.jl:416 [inlined]
 [5] _setindex!
   @ ./abstractarray.jl:1297 [inlined]
 [6] setindex!
   @ ./abstractarray.jl:1267 [inlined]
 [7] fill!(A::OffsetMatrix{Float64, DArray{Float64, 2, Matrix{Float64}}}, x::Int64)
   @ Base ./multidimensional.jl:1057
 [8] top-level scope
   @ REPL[11]:1
``` 
After this PR:
```julia
julia> fill!(OD, 2)
2×2 OffsetArray(::DArray{Float64, 2, Matrix{Float64}}, 1:2, 1:2) with eltype Float64 with indices 1:2×1:2:
 2.0  2.0
 2.0  2.0
```
2. specialize `zero`: This provides a performance boost with `StaticArrays`
On master:
```julia
julia> S = SVector{2,Int}(1,1)
2-element SVector{2, Int64} with indices SOneTo(2):
 1
 1

julia> SO = OffsetArray(S);

julia> @btime zero($SO);
  12.908 ns (1 allocation: 32 bytes)
```
After this PR:
```julia
julia> @btime zero($(Ref(SO))[]);
  4.787 ns (0 allocations: 0 bytes)
```