### PR TITLE
Generalize indexing AbstractUnitRanges with offset ranges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.9.2"
+version = "1.10.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -227,6 +227,14 @@ for T in [:AbstractUnitRange, :StepRange]
     end
 end
 
+# These methods are necessary to avoid ambiguity
+for R in [:IIUR, :IdOffsetRange]
+    @eval @inline function Base.getindex(r::IdOffsetRange, s::$R)
+        @boundscheck checkbounds(r, s)
+        return _getindex(r, s)
+    end
+end
+
 # offset-preserve broadcasting
 Broadcast.broadcasted(::Base.Broadcast.DefaultArrayStyle{1}, ::typeof(-), r::IdOffsetRange{T}, x::Integer) where T =
     IdOffsetRange{T}(r.parent .- x, r.offset)

--- a/test/customranges.jl
+++ b/test/customranges.jl
@@ -1,0 +1,82 @@
+# Useful for testing indexing
+struct ZeroBasedRange{T,A<:AbstractRange{T}} <: AbstractRange{T}
+    a :: A
+    function ZeroBasedRange(a::AbstractRange{T}) where {T}
+        @assert !Base.has_offset_axes(a)
+        new{T, typeof(a)}(a)
+    end
+end
+
+struct ZeroBasedUnitRange{T,A<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
+    a :: A
+    function ZeroBasedUnitRange(a::AbstractUnitRange{T}) where {T}
+        @assert !Base.has_offset_axes(a)
+        new{T, typeof(a)}(a)
+    end
+end
+
+for Z in [:ZeroBasedRange, :ZeroBasedUnitRange]
+    @eval Base.parent(A::$Z) = A.a
+    @eval Base.first(A::$Z) = first(A.a)
+    @eval Base.length(A::$Z) = length(A.a)
+    @eval Base.last(A::$Z) = last(A.a)
+    @eval Base.size(A::$Z) = size(A.a)
+    @eval Base.axes(A::$Z) = map(x -> IdentityUnitRange(0:x-1), size(A.a))
+    @eval Base.getindex(A::$Z, i::Int) = A.a[i + 1]
+    @eval Base.getindex(A::$Z, i::Integer) = A.a[i + 1]
+    @eval Base.firstindex(A::$Z) = 0
+    @eval Base.step(A::$Z) = step(A.a)
+    @eval OffsetArrays.no_offset_view(A::$Z) = A.a
+    @eval function Base.show(io::IO, A::$Z)
+        show(io, A.a)
+        print(io, " with indices $(axes(A,1))")
+    end
+end
+
+for Z in [:ZeroBasedRange, :ZeroBasedUnitRange]
+    for R in [:AbstractRange, :AbstractUnitRange, :StepRange]
+        @eval @inline function Base.getindex(A::$Z, r::$R{<:Integer})
+            @boundscheck checkbounds(A, r)
+            OffsetArrays._indexedby(A.a[r .+ 1], axes(r))
+        end
+    end
+
+    for R in [:ZeroBasedUnitRange, :ZeroBasedRange]
+        @eval @inline function Base.getindex(A::$Z, r::$R{<:Integer})
+            @boundscheck checkbounds(A, r)
+            OffsetArrays._indexedby(A.a[r.a .+ 1], axes(r))
+        end
+    end
+
+    for R in [:IIUR, :IdOffsetRange]
+        @eval @inline function Base.getindex(A::$Z, r::$R)
+            @boundscheck checkbounds(A, r)
+            OffsetArrays._indexedby(A.a[r .+ 1], axes(r))
+        end
+    end
+
+    for R in [:AbstractUnitRange, :IdOffsetRange, :IdentityUnitRange, :SliceIntUR, :StepRange, :StepRangeLen, :LinRange]
+        @eval @inline function Base.getindex(A::$R, r::$Z)
+            @boundscheck checkbounds(A, r)
+            OffsetArrays._indexedby(A[r.a], axes(r))
+        end
+    end
+    @eval @inline function Base.getindex(A::StepRangeLen{<:Any,<:Base.TwicePrecision,<:Base.TwicePrecision}, r::$Z)
+        @boundscheck checkbounds(A, r)
+        OffsetArrays._indexedby(A[r.a], axes(r))
+    end
+end
+
+# A basic range that does not have specialized vector indexing methods defined
+# In this case the best that we may do is to return an OffsetArray
+# Despite this, an indexing operation involving this type should preserve the axes of the indices
+struct CustomRange{T,A<:AbstractRange{T}} <: AbstractRange{T}
+    a :: A
+end
+Base.parent(r::CustomRange) = r.a
+Base.size(r::CustomRange) = size(parent(r))
+Base.axes(r::CustomRange) = axes(parent(r))
+Base.first(r::CustomRange) = first(parent(r))
+Base.last(r::CustomRange) = last(parent(r))
+Base.step(r::CustomRange) = step(parent(r))
+Base.getindex(r::CustomRange, i::Int) = getindex(parent(r), i)


### PR DESCRIPTION
The main change is to define `getindex(::AbstractUnitRange, ::IdOffsetRange)` instead of `getindex(::UnitRange, ::IdOffsetRange)`, and similarly for `IdentityUnitRange`. This makes vector indexing preserve indices for custom unitrange types as well.

on v1.6
```julia
julia> Base.OneTo(4)[Base.IdentityUnitRange(2:3)]
2:3

julia> using OffsetArrays

julia> Base.OneTo(4)[Base.IdentityUnitRange(2:3)]
OffsetArrays.IdOffsetRange(values=2:3, indices=2:3)

julia> using StaticArrays

julia> SOneTo(3)[Base.IdentityUnitRange(2:3)]
OffsetArrays.IdOffsetRange(values=2:3, indices=2:3)
```