### PR TITLE
Reshape with an offset parent array

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -11,15 +11,15 @@ export OffsetArray, OffsetMatrix, OffsetVector
 
 const IIUR = IdentityUnitRange{<:AbstractUnitRange{<:Integer}}
 
+include("axes.jl")
+include("utils.jl")
+include("origin.jl")
+
 # Technically we know the length of CartesianIndices but we need to convert it first, so here we
 # don't put it in OffsetAxisKnownLength.
 const OffsetAxisKnownLength = Union{Integer, AbstractUnitRange}
 const OffsetAxis = Union{OffsetAxisKnownLength, Colon}
 const ArrayInitializer = Union{UndefInitializer, Missing, Nothing}
-
-include("axes.jl")
-include("utils.jl")
-include("origin.jl")
 
 ## OffsetArray
 """
@@ -350,10 +350,9 @@ end
 # try to pass on the indices as received to the parent.
 # If the parent doesn't define an appropriate method, this will fall back to using the lengths
 # Short-circuit the case with matching indices to circumvent the Base restriction to 1-based indices
-_reshape(A::AbstractArray{<:Any,N}, ::NTuple{N,Union{Integer, AbstractUnitRange}}) where {N} = A
-_reshape(A::AbstractArray{<:Any,N}, inds::NTuple{N,OffsetAxis}) where {N} = (_colon_check(inds); A)
+_reshape(A::AbstractVector, ::Tuple{OffsetAxis}) = A
 _reshape(A, inds) = reshape(A, inds)
-_reshape_nov(A, inds) = no_offset_view(_reshape(A, inds))
+_reshape_nov(A, inds) = _reshape(no_offset_view(A), inds)
 
 Base.reshape(A::OffsetArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}}) =
     OffsetArray(_reshape(parent(A), inds), map(_toaxis, inds))

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -340,30 +340,39 @@ _similar_axes_or_length(AT, ax::I, ::I) where {I} = similar(AT, map(_indexlength
 # reshape accepts a single colon
 Base.reshape(A::AbstractArray, inds::OffsetAxis...) = reshape(A, inds)
 function Base.reshape(A::AbstractArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}})
-    AR = reshape(A, map(_indexlength, inds))
+    AR = reshape(no_offset_view(A), map(_indexlength, inds))
     O = OffsetArray(AR, map(_offset, axes(AR), inds))
     return _popreshape(O, axes(AR), _filterreshapeinds(inds))
 end
 
 # Reshaping OffsetArrays can "pop" the original OffsetArray wrapper and return
 # an OffsetArray(reshape(...)) instead of an OffsetArray(reshape(OffsetArray(...)))
-# try to pass on the indices as received to the parent.
-# If the parent doesn't define an appropriate method, this will fall back to using the lengths
-# Short-circuit the case with matching indices to circumvent the Base restriction to 1-based indices
-_reshape(A::AbstractVector, ::Tuple{OffsetAxis}) = A
-_reshape(A, inds) = reshape(A, inds)
+# Short-circuit for AbstractVectors if the axes are compatible to get around the Base restriction
+# to 1-based vectors
+function _reshape(A::AbstractVector, inds::Tuple{OffsetAxis})
+    @noinline throw_dimerr(ind::Integer) = throw(
+        DimensionMismatch("parent has $(size(A,1)) elements, which is incompatible with length $ind"))
+    @noinline throw_dimerr(ind) = throw(
+        DimensionMismatch("parent has $(size(A,1)) elements, which is incompatible with indices $ind"))
+    _checksize(first(inds), size(A,1)) || throw_dimerr(first(inds))
+    A
+end
+_reshape(A, inds) = _reshape2(A, inds)
+_reshape2(A, inds) = reshape(A, inds)
+# avoid a stackoverflow by relegating to the parent if no_offset_view returns an offsetarray
+_reshape2(A::OffsetArray, inds) = reshape(parent(A), inds)
 _reshape_nov(A, inds) = _reshape(no_offset_view(A), inds)
 
 Base.reshape(A::OffsetArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}}) =
     OffsetArray(_reshape(parent(A), inds), map(_toaxis, inds))
 # And for non-offset axes, we can just return a reshape of the parent directly
-Base.reshape(A::OffsetArray, inds::Tuple{Union{Integer,Base.OneTo},Vararg{Union{Integer,Base.OneTo}}}) = _reshape_nov(parent(A), inds)
-Base.reshape(A::OffsetArray, inds::Dims) = _reshape_nov(parent(A), inds)
+Base.reshape(A::OffsetArray, inds::Tuple{Union{Integer,Base.OneTo},Vararg{Union{Integer,Base.OneTo}}}) = _reshape_nov(A, inds)
+Base.reshape(A::OffsetArray, inds::Dims) = _reshape_nov(A, inds)
 Base.reshape(A::OffsetVector, ::Colon) = A
 Base.reshape(A::OffsetVector, ::Tuple{Colon}) = A
 Base.reshape(A::OffsetArray, ::Colon) = reshape(A, (Colon(),))
 Base.reshape(A::OffsetArray, inds::Union{Int,Colon}...) = reshape(A, inds)
-Base.reshape(A::OffsetArray, inds::Tuple{Vararg{Union{Int,Colon}}}) = _reshape_nov(parent(A), inds)
+Base.reshape(A::OffsetArray, inds::Tuple{Vararg{Union{Int,Colon}}}) = _reshape_nov(A, inds)
 
 # permutedims in Base does not preserve axes, and can not be fixed in a non-breaking way
 # This is a stopgap solution

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,7 +7,7 @@ _indexlength(i::Integer) = Int(i)
 _indexlength(i::Colon) = Colon()
 
 _toaxis(i::Integer) = Base.OneTo(i)
-_toaxis(i::OffsetAxis) = i
+_toaxis(i) = i
 
 _strip_IdOffsetRange(r::IdOffsetRange) = parent(r)
 _strip_IdOffsetRange(r) = r
@@ -113,20 +113,3 @@ _filterreshapeinds(t::Tuple) = _filterreshapeinds(tail(t))
 _filterreshapeinds(t::Tuple{}) = t
 _popreshape(A::AbstractArray, ax::Tuple{Vararg{Base.OneTo}}, inds::Tuple{}) = no_offset_view(A)
 _popreshape(A::AbstractArray, ax, inds) = A
-
-# derived from Base._reshape_uncolon
-# https://github.com/JuliaLang/julia/blob/d29126a43ee289fc5ab8fcb3dc0e03f514605950/base/reshapedarray.jl#L119-L137
-@inline function _colon_check(dims)
-    @noinline throw1(dims) = throw(DimensionMismatch(string("new dimensions $(dims) ",
-        "may have at most one omitted dimension specified by `Colon()`")))
-    post = _after_colon(dims...)
-    _any_colon(post...) && throw1(dims)
-    nothing
-end
-@inline _any_colon() = false
-@inline _any_colon(dim::Colon, tail...) = true
-@inline _any_colon(dim::Any, tail...) = _any_colon(tail...)
-# @inline _before_colon(dim::Any, tail...) = (dim, _before_colon(tail...)...)
-# @inline _before_colon(dim::Colon, tail...) = ()
-@inline _after_colon(dim::Any, tail...) =  _after_colon(tail...)
-@inline _after_colon(dim::Colon, tail...) = tail

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,7 +2,6 @@
 
 _indexoffset(r::AbstractRange) = first(r) - 1
 _indexoffset(i::Integer) = 0
-_indexoffset(i::Colon) = 0
 _indexlength(r::AbstractRange) = length(r)
 _indexlength(i::Integer) = Int(i)
 _indexlength(i::Colon) = Colon()

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,6 +6,12 @@ _indexlength(r::AbstractRange) = length(r)
 _indexlength(i::Integer) = Int(i)
 _indexlength(i::Colon) = Colon()
 
+# utility methods used in reshape
+# we don't use _indexlength in this to avoid converting the arguments to Int
+_checksize(ind::Integer, s) = ind == s
+_checksize(ind::AbstractUnitRange, s) = length(ind) == s
+_checksize(::Colon, s) = true
+
 _toaxis(i::Integer) = Base.OneTo(i)
 _toaxis(i) = i
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -115,6 +115,8 @@ _filterreshapeinds(t::Tuple{}) = t
 _popreshape(A::AbstractArray, ax::Tuple{Vararg{Base.OneTo}}, inds::Tuple{}) = no_offset_view(A)
 _popreshape(A::AbstractArray, ax, inds) = A
 
+# derived from Base._reshape_uncolon
+# https://github.com/JuliaLang/julia/blob/d29126a43ee289fc5ab8fcb3dc0e03f514605950/base/reshapedarray.jl#L119-L137
 @inline function _colon_check(dims)
     @noinline throw1(dims) = throw(DimensionMismatch(string("new dimensions $(dims) ",
         "may have at most one omitted dimension specified by `Colon()`")))
@@ -125,7 +127,7 @@ end
 @inline _any_colon() = false
 @inline _any_colon(dim::Colon, tail...) = true
 @inline _any_colon(dim::Any, tail...) = _any_colon(tail...)
-@inline _before_colon(dim::Any, tail...) = (dim, _before_colon(tail...)...)
-@inline _before_colon(dim::Colon, tail...) = ()
+# @inline _before_colon(dim::Any, tail...) = (dim, _before_colon(tail...)...)
+# @inline _before_colon(dim::Colon, tail...) = ()
 @inline _after_colon(dim::Any, tail...) =  _after_colon(tail...)
 @inline _after_colon(dim::Colon, tail...) = tail

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,7 +10,6 @@ _indexlength(i::Colon) = Colon()
 # we don't use _indexlength in this to avoid converting the arguments to Int
 _checksize(ind::Integer, s) = ind == s
 _checksize(ind::AbstractUnitRange, s) = length(ind) == s
-_checksize(::Colon, s) = true
 
 _toaxis(i::Integer) = Base.OneTo(i)
 _toaxis(i) = i

--- a/test/customranges.jl
+++ b/test/customranges.jl
@@ -65,6 +65,10 @@ for Z in [:ZeroBasedRange, :ZeroBasedUnitRange]
         @boundscheck checkbounds(A, r)
         OffsetArrays._indexedby(A[r.a], axes(r))
     end
+
+    @eval Base.reshape(z::$Z, inds::Tuple{}) = reshape(parent(z), inds)
+    @eval Base.reshape(z::$Z, inds::Tuple{Int, Vararg{Int}}) = reshape(parent(z), inds)
+    @eval Base.reshape(z::$Z, inds::Tuple{Union{Int, AbstractUnitRange{<:Integer}}, Vararg{Union{Int, AbstractUnitRange{<:Integer}}}}) = reshape(parent(z), inds)
 end
 
 # A basic range that does not have specialized vector indexing methods defined

--- a/test/customranges.jl
+++ b/test/customranges.jl
@@ -79,6 +79,7 @@ struct CustomRange{T,A<:AbstractRange{T}} <: AbstractRange{T}
 end
 Base.parent(r::CustomRange) = r.a
 Base.size(r::CustomRange) = size(parent(r))
+Base.length(r::CustomRange) = length(parent(r))
 Base.axes(r::CustomRange) = axes(parent(r))
 Base.first(r::CustomRange) = first(parent(r))
 Base.last(r::CustomRange) = last(parent(r))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1756,6 +1756,25 @@ end
     @test axes(R) == (1:2, 1:3)
     R = reshape(zeros(6,1), 1:2, :)
     @test axes(R) == (1:2, 1:3)
+
+    r = OffsetArray(ZeroBasedRange(3:4), 1);
+    @test reshape(r, 2) == 3:4
+    @test reshape(r, (2,)) == 3:4
+    @test reshape(r, :) == 3:4
+    @test reshape(r, (:,)) == 3:4
+
+    @test reshape(r, (2,:,4:4)) == OffsetArray(reshape(3:4, 2, 1, 1), 1:2, 1:1, 4:4)
+
+    # reshape works even if the parent doesn't have 1-based indices
+    # this works even if the parent doesn't support the reshape
+    r = OffsetArray(IdentityUnitRange(0:1), -1)
+    @test reshape(r, 2) == 0:1
+    @test reshape(r, (2,)) == 0:1
+    @test reshape(r, :) == OffsetArray(0:1, -1:0)
+    @test reshape(r, (:,)) == OffsetArray(0:1, -1:0)
+
+    # more than one colon is not allowed
+    @test_throws Exception reshape(ones(3:4, 4:5, 1:2), :, :, 2)
 end
 
 @testset "permutedims" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1780,6 +1780,7 @@ end
 
     # more than one colon is not allowed
     @test_throws Exception reshape(ones(3:4, 4:5, 1:2), :, :, 2)
+    @test_throws Exception reshape(ones(3:4, 4:5, 1:2), :, 2, :)
 end
 
 @testset "permutedims" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1781,6 +1781,19 @@ end
     # more than one colon is not allowed
     @test_throws Exception reshape(ones(3:4, 4:5, 1:2), :, :, 2)
     @test_throws Exception reshape(ones(3:4, 4:5, 1:2), :, 2, :)
+
+    A = OffsetArray(rand(4, 4), -1, -1);
+    B = reshape(A, (2, :))
+    @test axes(B, 1) == 1:2
+    @test axes(B, 2) == 1:8
+
+    # some more exotic vector types
+    r = OffsetVector(CustomRange(ZeroBasedRange(0:2)), -2)
+    r2 = reshape(r, :)
+    @test r2 == r
+    r2 = reshape(r, 3)
+    @test axes(r2, 1) == 1:3
+    @test r2 == no_offset_view(r)
 end
 
 @testset "permutedims" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1799,9 +1799,6 @@ end
     rp = parent(r)
     @test axes(reshape(rp, 4:6), 1) == 4:6
     @test axes(reshape(r, (3,1))) == (1:3, 1:1)
-    # the following is broken if rp doesn't define its own reshape
-    # we may fix it here but that's perhaps too much type-piracy
-    @test_broken reshape(rp, length(rp))
 end
 
 @testset "permutedims" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1763,7 +1763,10 @@ end
     @test reshape(r, :) == 3:4
     @test reshape(r, (:,)) == 3:4
 
-    @test reshape(r, (2,:,4:4)) == OffsetArray(reshape(3:4, 2, 1, 1), 1:2, 1:1, 4:4)
+    # getindex for a reshaped array that wraps an offset array is broken on 1.0
+    if VERSION >= v"1.1"
+        @test reshape(r, (2,:,4:4)) == OffsetArray(reshape(3:4, 2, 1, 1), 1:2, 1:1, 4:4)
+    end
 
     # reshape works even if the parent doesn't have 1-based indices
     # this works even if the parent doesn't support the reshape

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1776,6 +1776,8 @@ end
     @test reshape(r, :) == OffsetArray(0:1, -1:0)
     @test reshape(r, (:,)) == OffsetArray(0:1, -1:0)
 
+    @test reshape(ones(2:3, 4:5), (2, :)) == ones(2,2)
+
     # more than one colon is not allowed
     @test_throws Exception reshape(ones(3:4, 4:5, 1:2), :, :, 2)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1794,6 +1794,14 @@ end
     r2 = reshape(r, 3)
     @test axes(r2, 1) == 1:3
     @test r2 == no_offset_view(r)
+    @test_throws Exception reshape(r, length(r) + 1)
+    @test_throws Exception reshape(r, 1:length(r) + 1)
+    rp = parent(r)
+    @test axes(reshape(rp, 4:6), 1) == 4:6
+    @test axes(reshape(r, (3,1))) == (1:3, 1:1)
+    # the following is broken if rp doesn't define its own reshape
+    # we may fix it here but that's perhaps too much type-piracy
+    @test_broken reshape(rp, length(rp))
 end
 
 @testset "permutedims" begin


### PR DESCRIPTION
Fixes #219 

Now
```julia
julia> r = OffsetArray(IdentityUnitRange(0:1), -1)
Base.IdentityUnitRange(0:1) with indices -1:0

julia> reshape(r, 2) # Int arguments strip offsets
0:1

julia> reshape(r, (2,))
0:1

julia> reshape(r, :) # Colon preserves offsets for an OffsetVector
Base.IdentityUnitRange(0:1) with indices -1:0

julia> reshape(r, (:,))
Base.IdentityUnitRange(0:1) with indices -1:0
```

The last one is a bugfix, as on master

```julia
julia> reshape(r, :)
Base.IdentityUnitRange(0:1) with indices -1:0

julia> reshape(r, (:,))
ERROR: ArgumentError: offset arrays are not supported but got an array with index other than 1
Stacktrace:
```