### PR TITLE
limit type-piracy in getindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 [compat]
 Adapt = "2, 3"
 Aqua = "0.5"
-ArrayInterface = "3"
 CatIndices = "0.2"
 DistributedArrays = "0.6"
 Documenter = "0.26"
@@ -19,7 +18,6 @@ julia = "0.7, 1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 DistributedArrays = "aaf54ef3-cdf8-58ed-94cc-d582ad619b94"
@@ -31,4 +29,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ArrayInterface", "Aqua", "CatIndices", "DistributedArrays", "DelimitedFiles", "Documenter", "Test", "LinearAlgebra", "EllipsisNotation", "StaticArrays", "FillArrays"]
+test = ["Aqua", "CatIndices", "DistributedArrays", "DelimitedFiles", "Documenter", "Test", "LinearAlgebra", "EllipsisNotation", "StaticArrays", "FillArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 [compat]
 Adapt = "2, 3"
 Aqua = "0.5"
+ArrayInterface = "3"
 CatIndices = "0.2"
 DistributedArrays = "0.6"
 Documenter = "0.26"
@@ -18,6 +19,7 @@ julia = "0.7, 1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 DistributedArrays = "aaf54ef3-cdf8-58ed-94cc-d582ad619b94"
@@ -29,4 +31,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "CatIndices", "DistributedArrays", "DelimitedFiles", "Documenter", "Test", "LinearAlgebra", "EllipsisNotation", "StaticArrays", "FillArrays"]
+test = ["ArrayInterface", "Aqua", "CatIndices", "DistributedArrays", "DelimitedFiles", "Documenter", "Test", "LinearAlgebra", "EllipsisNotation", "StaticArrays", "FillArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.11.0"
+version = "1.10.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.10.0"
+version = "1.11.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -509,7 +509,7 @@ end
 @inline _boundscheck_return(r, s) = (@boundscheck checkbounds(r, s); s)
 
 for OR in [:IIUR, :IdOffsetRange]
-    for R in [:StepRange, :StepRangeLen, :LinRange, :AbstractUnitRange]
+    for R in [:StepRange, :StepRangeLen, :LinRange, :UnitRange, :(Base.OneTo)]
         @eval @inline Base.getindex(r::$R, s::$OR) = _boundscheck_index_retaining_axes(r, s)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,14 @@ function same_value(r1, r2)
     return true
 end
 
+module AmbiguityTest
+    using Test
+    using ArrayInterface
+    using OffsetArrays
+    using Aqua
+    Aqua.test_ambiguities([OffsetArrays, ArrayInterface])
+end
+
 @testset "Project meta quality checks" begin
     # Not checking compat section for test-only dependencies
     Aqua.test_all(OffsetArrays; project_extras=true, deps_compat=true, stale_deps=true, project_toml_formatting=true)
@@ -1083,7 +1091,6 @@ end
         Base.OneTo(1000),
         CustomRange(Base.OneTo(1000)),
         Slice(Base.OneTo(1000)),
-        SOneTo(1000),
         1:1000,
         UnitRange(1.0, 1000.0),
         1:3:1000,
@@ -1228,7 +1235,6 @@ end
         # AbstractRanges
         Base.OneTo(1000),
         Slice(Base.OneTo(1000)),
-        SOneTo(1000),
         CustomRange(Base.OneTo(1000)),
         1:1000,
         UnitRange(1.0, 1000.0),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,14 +39,6 @@ function same_value(r1, r2)
     return true
 end
 
-module AmbiguityTest
-    using Test
-    using ArrayInterface
-    using OffsetArrays
-    using Aqua
-    Aqua.test_ambiguities([OffsetArrays, ArrayInterface])
-end
-
 @testset "Project meta quality checks" begin
     # Not checking compat section for test-only dependencies
     Aqua.test_all(OffsetArrays; project_extras=true, deps_compat=true, stale_deps=true, project_toml_formatting=true)


### PR DESCRIPTION
Fix to address https://github.com/JuliaArrays/ArrayInterface.jl/issues/170. Technically it's breaking, as it reverts #244 for custom `AbstractUnitRange`s, however since ranges are treated to be equal based only on value, this won't lead to errors unless one specifically relies on the indices as computed in #244 for custom range types. Since that behavior was type-piracy anyway, I wonder if this may be treated as a minor change?

In any case this may be a temporary fix if https://github.com/JuliaLang/julia/pull/41284 is merged.