### PR TITLE
fix indexing for OneTo on v1.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.10.1"
+version = "1.10.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -519,7 +519,7 @@ for OR in [:IIUR, :IdOffsetRange]
     end
 end
 Base.getindex(r::Base.OneTo, s::IdOffsetRange) = _boundscheck_index_retaining_axes(r, s)
-if VERSION < v"1.7.0"
+if VERSION < v"1.7.0-beta2"
     Base.getindex(r::Base.OneTo, s::IIUR) = _boundscheck_index_retaining_axes(r, s)
 end
 
@@ -632,9 +632,9 @@ no_offset_view(a::Array) = a
 no_offset_view(i::Number) = i
 no_offset_view(A::AbstractArray) = _no_offset_view(axes(A), A)
 _no_offset_view(::Tuple{}, A::AbstractArray{T,0}) where T = A
-_no_offset_view(::Tuple{<:Base.OneTo,Vararg{<:Base.OneTo}}, A::AbstractArray) = A
+_no_offset_view(::Tuple{Base.OneTo, Vararg{Base.OneTo}}, A::AbstractArray) = A
 # the following method is needed for ambiguity resolution
-_no_offset_view(::Tuple{<:Base.OneTo,Vararg{<:Base.OneTo}}, A::AbstractUnitRange) = A
+_no_offset_view(::Tuple{Base.OneTo, Vararg{Base.OneTo}}, A::AbstractUnitRange) = A
 _no_offset_view(::Any, A::AbstractArray) = OffsetArray(A, Origin(1))
 _no_offset_view(::Any, A::AbstractUnitRange) = UnitRange(A)
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -509,7 +509,7 @@ end
 @inline _boundscheck_return(r, s) = (@boundscheck checkbounds(r, s); s)
 
 for OR in [:IIUR, :IdOffsetRange]
-    for R in [:StepRange, :StepRangeLen, :LinRange, :UnitRange, :(Base.OneTo)]
+    for R in [:StepRange, :StepRangeLen, :LinRange, :UnitRange]
         @eval @inline Base.getindex(r::$R, s::$OR) = _boundscheck_index_retaining_axes(r, s)
     end
 
@@ -517,6 +517,10 @@ for OR in [:IIUR, :IdOffsetRange]
     @eval @inline function Base.getindex(r::StepRangeLen{T,<:Base.TwicePrecision,<:Base.TwicePrecision}, s::$OR) where T
         _boundscheck_index_retaining_axes(r, s)
     end
+end
+Base.getindex(r::Base.OneTo, s::IdOffsetRange) = _boundscheck_index_retaining_axes(r, s)
+if VERSION < v"1.7.0"
+    Base.getindex(r::Base.OneTo, s::IIUR) = _boundscheck_index_retaining_axes(r, s)
 end
 
 # These methods are added to avoid ambiguities with Base.


### PR DESCRIPTION
With https://github.com/JuliaLang/julia/pull/40997 now merged and available on v1.7.0-beta2, we don't need to define indexing for `OneTo` with `IdentityUnitRange` in this package. This reduces type-piracy, and also doesn't overwrite the method from `Base`. 

Also remove deprecated `UnionAll` declarations in `Varrag` in `no_offset_view`.

Tests now pass with `--depwarn=error`