### PR TITLE
deprecate the roundmode method for `centered`

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -694,7 +694,7 @@ function center(A::AbstractArray, r::RoundingMode=RoundDown)
 end
 
 """
-    centered(A, r::RoundingMode=RoundDown) -> Ao
+    centered(A, cp=center(A)) -> Ao
 
 Shift the center coordinate of array `A` to `(0, 0, ...)`. If `size(A, k)`
 is even, a rounding procedure will be applied with mode `r`.
@@ -718,10 +718,9 @@ Aoo[0, 0] == 5 # true
 true
 ```
 
-To query the center coordinate of the given array, you can
-instead use [`center`](@ref OffsetArrays.center).
+See also [`center`](@ref OffsetArrays.center).
 """
-centered(A::AbstractArray, r::RoundingMode=RoundDown) = OffsetArray(A, .-center(A, r))
+centered(A::AbstractArray, cp::Dims=center(A)) = OffsetArray(A, .-cp)
 
 
 ####
@@ -813,5 +812,13 @@ if Base.VERSION >= v"1.4.2"
     include("precompile.jl")
     _precompile_()
 end
+
+
+##
+# Deprecations
+##
+
+# This is a bad API design as it introduces counter intuitive results (#250)
+@deprecate centered(A::AbstractArray, r::RoundingMode) OffsetArray(A, .-center(A, r))
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2505,20 +2505,21 @@ end
     @testset "centered" begin
         A = reshape(collect(1:9), 3, 3)
         Ao = OffsetArrays.centered(A)
+        @test OffsetArrays.centered(Ao) === Ao
+        @test OffsetArrays.centered(Ao, OffsetArrays.center(Ao)) === Ao
         @test typeof(Ao) <: OffsetArray
         @test parent(Ao) === A
         @test Ao.offsets == (-2, -2)
         @test Ao[0, 0] == 5
-        @test OffsetArrays.centered(A, RoundDown) == OffsetArrays.centered(A, RoundUp)
 
         A = reshape(collect(1:6), 2, 3)
         Ao = OffsetArrays.centered(A)
-        @test OffsetArrays.centered(A, RoundDown) == Ao
+        @test OffsetArrays.centered(A, OffsetArrays.center(A, RoundDown)) == Ao
         @test typeof(Ao) <: OffsetArray
         @test parent(Ao) === A
         @test Ao.offsets == (-1, -2)
         @test Ao[0, 0] == 3
-        Ao = OffsetArrays.centered(A, RoundUp)
+        Ao = OffsetArrays.centered(A, OffsetArrays.center(A, RoundUp))
         @test typeof(Ao) <: OffsetArray
         @test parent(Ao) === A
         @test Ao.offsets == (-2, -2)
@@ -2545,4 +2546,10 @@ include("origin.jl")
     @test OffsetArrays._addoffset(Base.OneTo(2), 1) == 2:3
     @test OffsetArrays._addoffset(3:2:9, 1) isa AbstractRange{Int}
     @test OffsetArrays._addoffset(3:2:9, 1) == 4:2:10
+end
+
+@info "Following deprecations are expected"
+@testset "deprecations" begin
+    A = reshape(collect(1:9), 3, 3)
+    @test OffsetArrays.centered(A, RoundDown) == OffsetArrays.centered(A, RoundUp)
 end


### PR DESCRIPTION
This was really a design mistake and I still can't believe I ignored that obvious conflict especially I did write a test case for it. 😢 

The new `cp` method is quite trivial, but I feel it's conceptually as meaningful as `OffsetArrays.Origin`.

fixes #250