### PR TITLE
unexport the exported deprecation symbol `centered`

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -819,6 +819,6 @@ end
 ##
 
 # This is a bad API design as it introduces counter intuitive results (#250)
-@deprecate centered(A::AbstractArray, r::RoundingMode) OffsetArray(A, .-center(A, r))
+@deprecate centered(A::AbstractArray, r::RoundingMode) OffsetArray(A, .-center(A, r)) false
 
 end # module


### PR DESCRIPTION
Always forget that `@deprecate` will export the deprecated symbol by default.

This has introduced a symbol conflict in https://github.com/JuliaImages/ImageQualityIndexes.jl/pull/36

This is a bug fix so I'll bump a patch version after merging.