### PR TITLE
Propagate iteration to parent in OffsetArrays

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -441,6 +441,8 @@ end
     A
 end
 
+@inline Base.iterate(a::OffsetArray, i...) = iterate(parent(a), i...)
+
 Base.in(x, A::OffsetArray) = in(x, parent(A))
 Base.copy(A::OffsetArray) = parent_call(copy, A)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1493,10 +1493,10 @@ end
         end
     end
 
+    v = ones(10)
     for r in Any[1:1:10, 1:10], s in Any[r, collect(r)]
-        ro = OffsetArray(r)
-        v = ones(10)
-        @test Float64[v[i] for i in r] == Float64[v[i] for i in ro]
+        so = OffsetArray(s)
+        @test Float64[v[i] for i in s] == Float64[v[i] for i in so]
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1492,6 +1492,12 @@ end
             @test a == d
         end
     end
+
+    for r in Any[1:1:10, 1:10], s in Any[r, collect(r)]
+        ro = OffsetArray(r)
+        v = ones(10)
+        @test Float64[v[i] for i in r] == Float64[v[i] for i in ro]
+    end
 end
 
 @testset "show/summary" begin


### PR DESCRIPTION
This provides a performance boost, especially for ranges but also to some extent for arrays.

On master
```julia
julia> r = 1:1:1000; ro = OffsetArray(r); s = collect(r); so = OffsetArray(s);

julia> v = ones(1000);

julia> @btime $v[$r];
  2.010 μs (1 allocation: 7.94 KiB)

julia> @btime $v[$ro];
  25.848 μs (1 allocation: 7.94 KiB)

julia> @btime $v[$s];
  1.897 μs (1 allocation: 7.94 KiB)

julia> @btime $v[$so];
  3.859 μs (1 allocation: 7.94 KiB)
```

After this PR
```julia
julia> @btime $v[$ro];
  1.679 μs (1 allocation: 7.94 KiB)

julia> @btime $v[$so];
  1.862 μs (1 allocation: 7.94 KiB)
```