### PR TITLE
Add similar(::Type{<:OffsetArray}, axes)

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -320,6 +320,7 @@ function Base.similar(A::AbstractArray, ::Type{T}, shape::Tuple{OffsetAxisKnownL
     P = _similar_axes_or_length(A, T, new_shape, shape)
     return OffsetArray(P, map(_offset, axes(P), shape))
 end
+Base.similar(::Type{A}, sz::Tuple{Vararg{Int}}) where {A<:OffsetArray} = similar(Array{eltype(A)}, sz)
 function Base.similar(::Type{T}, shape::Tuple{OffsetAxisKnownLength,Vararg{OffsetAxisKnownLength}}) where {T<:AbstractArray}
     new_shape = map(_strip_IdOffsetRange, shape)
     P = _similar_axes_or_length(T, new_shape, shape)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1681,8 +1681,8 @@ end
     testsimilar(typeof(A), (:, 1:3))
 
     @testset "similar with OffsetArray type (issue #263)" begin
-        for i in Any[[1,2,3], 1:3, SVector{2,Int}(1,2)]
-            k = OffsetArray(i, -2)
+        for i in Any[[1,2,3], 1:3, SVector{2,Int}(1,2), reshape(1:4, 2, 2)]
+            k = OffsetArray(i, map(x -> -2, size(i)))
             j = similar(typeof(k), axes(k))
             @test axes(j) == axes(k)
             @test eltype(j) == eltype(k)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1682,9 +1682,14 @@ end
 
     @testset "similar with OffsetArray type (issue #263)" begin
         for i in Any[[1,2,3], 1:3, SVector{2,Int}(1,2)]
-            io = OffsetArray(i, -2)
-            j = similar(typeof(io), axes(io))
-            @test axes(j) == axes(io)
+            k = OffsetArray(i, -2)
+            j = similar(typeof(k), axes(k))
+            @test axes(j) == axes(k)
+            @test eltype(j) == eltype(k)
+            j = similar(typeof(k), size(k))
+            @test eltype(j) == eltype(k)
+            @test size(j) == size(k)
+            @test all(==(1), first.(axes(j)))
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1679,6 +1679,14 @@ end
     testsimilar(typeof(A), (:, :))
     testsimilar(typeof(A), (:, 2))
     testsimilar(typeof(A), (:, 1:3))
+
+    @testset "similar with OffsetArray type (issue #263)" begin
+        for i in Any[[1,2,3], 1:3, SVector{2,Int}(1,2)]
+            io = OffsetArray(i, -2)
+            j = similar(typeof(io), axes(io))
+            @test axes(j) == axes(io)
+        end
+    end
 end
 
 @testset "reshape" begin


### PR DESCRIPTION
Fixes #263 by replacing `O::Type{<:OffsetArray}` with `Array{eltype(O)}` in similar.

I'm not too sure about this, as `eltype` may not be inferred in general, and the `similar` method doesn't work for arbitrary types anyway. However this might be useful in certain cases.