### PR TITLE
Depend on ArrayInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,19 @@ version = "1.10.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 
 [compat]
 Adapt = "2, 3"
 Aqua = "0.5"
+ArrayInterface = "3"
 CatIndices = "0.2"
 DistributedArrays = "0.6"
 Documenter = "0.27"
 EllipsisNotation = "1"
 FillArrays = "0.11"
+Static = "0.3"
 StaticArrays = "1"
 julia = "0.7, 1"
 


### PR DESCRIPTION
This is an initial attempt to start getting rid of `Requires` for ArrayInterface.