### PR TITLE
Allow some linear algebra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "1.10.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 Adapt = "2, 3"
@@ -24,7 +25,6 @@ DistributedArrays = "aaf54ef3-cdf8-58ed-94cc-d582ad619b94"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -651,6 +651,7 @@ if isdefined(Base, :IdentityUnitRange)
     no_offset_view(a::Base.Slice) = Base.Slice(UnitRange(a))
     no_offset_view(S::SubArray) = view(parent(S), map(no_offset_view, parentindices(S))...)
 end
+no_offset_view(A::PermutedDimsArray{T,N,perm,iperm,P}) where {T,N,perm,iperm,P} = PermutedDimsArray(no_offset_view(parent(A)), perm)
 no_offset_view(a::Array) = a
 no_offset_view(i::Number) = i
 no_offset_view(A::AbstractArray) = _no_offset_view(axes(A), A)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -853,6 +853,8 @@ end
 import Adapt
 Adapt.adapt_structure(to, O::OffsetArray) = parent_call(x -> Adapt.adapt(to, x), O)
 
+include("linearalgebra.jl")
+
 if Base.VERSION >= v"1.4.2"
     include("precompile.jl")
     _precompile_()

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -1,0 +1,94 @@
+using LinearAlgebra
+using LinearAlgebra: MulAddMul, mul!
+lapack_axes(t::AbstractChar, M::AbstractVecOrMat) = (axes(M, t=='N' ? 1 : 2), axes(M, t=='N' ? 2 : 1))
+
+# The signature of this differs from LinearAlgebra's only on C
+function LinearAlgebra.generic_matvecmul!(C::OffsetVector, tA, A::AbstractVecOrMat, B::AbstractVector,
+                            _add::MulAddMul = MulAddMul())
+
+    mB_axis = Base.axes1(B)
+    mA_axis, nA_axis = lapack_axes(tA, A)
+
+    if mB_axis != nA_axis
+        throw(DimensionMismatch("mul! can't contract axis $(UnitRange(nA_axis)) from A with axes(B) == ($(UnitRange(mB_axis)),)"))
+    end
+    if mA_axis != Base.axes1(C)
+        throw(DimensionMismatch("mul! got axes(C) == ($(UnitRange(Base.axes1(C))),), expected $(UnitRange(mA_axis))"))
+    end
+
+    C1 = no_offset_view(C)
+    A1 = no_offset_view(A)
+    B1 = no_offset_view(B)
+
+    if tA == 'T'
+        mul!(C1, transpose(A1),  B1, _add.alpha, _add.beta)
+    elseif tA == 'C'
+        mul!(C1, adjoint(A1), B1, _add.alpha, _add.beta)
+    elseif tA == 'N'
+        mul!(C1, A1, B1, _add.alpha, _add.beta)
+    else
+        error("illegal char")
+    end
+
+    C
+end
+
+LinearAlgebra.generic_matmatmul!(C::OffsetMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
+                             _add::MulAddMul) = unwrap_matmatmul!(C, tA, tB, A, B, _add)
+LinearAlgebra.generic_matmatmul!(C::Union{OffsetMatrix, OffsetVector}, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat,
+                             _add::MulAddMul) = unwrap_matmatmul!(C, tA, tB, A, B, _add)
+
+function unwrap_matmatmul!(C::Union{OffsetMatrix, OffsetVector}, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat,
+                             _add::MulAddMul)
+
+    mA_axis, nA_axis = lapack_axes(tA, A)
+    mB_axis, nB_axis = lapack_axes(tB, B)
+
+    if nA_axis != mB_axis
+        throw(DimensionMismatch("mul! can't contract axis $(UnitRange(nA_axis)) from A with $(UnitRange(mB_axis)) from B"))
+    elseif mA_axis != axes(C,1)
+        throw(DimensionMismatch("mul! got axes(C,1) == $(UnitRange(axes(C,1))), expected $(UnitRange(mA_axis)) from A"))
+    elseif nB_axis != axes(C,2)
+        throw(DimensionMismatch("mul! got axes(C,2) == $(UnitRange(axes(C,2))), expected $(UnitRange(nB_axis)) from B"))
+    end
+
+    C1 = no_offset_view(C)
+    A1 = no_offset_view(A)
+    B1 = no_offset_view(B)
+
+   if tA == 'N'
+        if tB == 'N'
+            mul!(C1, A1, B1, _add.alpha, _add.beta)
+        elseif tB == 'T'
+            mul!(C1, A1, transpose(B1), _add.alpha, _add.beta)
+        elseif tB == 'C'
+            mul!(C1, A1, adjoint(B1), _add.alpha, _add.beta)
+        else
+            error("illegal char")
+        end
+    elseif tA == 'T'
+        if tB == 'N'
+            mul!(C1, transpose(A1), B1, _add.alpha, _add.beta)
+        elseif tB == 'T'
+            mul!(C1, transpose(A1), transpose(B1), _add.alpha, _add.beta)
+        elseif tB == 'C'
+            mul!(C1, transpose(A1), adjoint(B1), _add.alpha, _add.beta)
+        else
+            error("illegal char")
+        end
+    elseif tA == 'C'
+        if tB == 'N'
+            mul!(C1, adjoint(A1), B1, _add.alpha, _add.beta)
+        elseif tB == 'T'
+            mul!(C1, adjoint(A1), transpose(B1), _add.alpha, _add.beta)
+        elseif tB == 'C'
+            mul!(C1, adjoint(A1), adjoint(B1), _add.alpha, _add.beta)
+        else
+            error("illegal char")
+        end
+    else
+        error("illegal char")
+    end
+
+    C
+end


### PR DESCRIPTION
This is meant to work with https://github.com/JuliaLang/julia/pull/43552, although I think `mul!` might work without that.

Alternative to #146. Since this does not overload `*`, I think it should not encounter the endless method ambiguities that tends to cause, against Adjoint matrices and other types. In fact I think other packages could overload `generic_matmul!` too in the same way, and each unwrap nicely, so long as they all only dispatch on the output `C`, which is created by `similar`.

This seems to cause one extra allocation and hence is slower than without offsets. I'm not so sure why, I thought `MulAddMul(α,β)` (whose type depends on the values of α,β) was the culprit, but in fact get similar times after avoiding that:
```julia
julia> for N in [3, 10, 100, 1000]
           @show N
           A, B, x = rand(N,N), rand(N,N), rand(N)
           @btime $A * $B
           A, B, x = OffsetArray(A,5,5), OffsetArray(B,5,5), OffsetArray(x,5)
           @btime $A * $B
       end
N = 3
  min 31.407 ns, mean 33.633 ns (1 allocation, 128 bytes)
  min 52.950 ns, mean 56.294 ns (2 allocations, 144 bytes)
N = 10
  min 180.901 ns, mean 200.923 ns (1 allocation, 896 bytes)
  min 209.057 ns, mean 225.422 ns (2 allocations, 912 bytes)
N = 100
  min 9.625 μs, mean 15.880 μs (2 allocations, 78.17 KiB)
  min 9.583 μs, mean 15.396 μs (3 allocations, 78.19 KiB)
N = 1000
  min 7.685 ms, mean 8.350 ms (2 allocations, 7.63 MiB)
  min 7.756 ms, mean 8.336 ms (3 allocations, 7.63 MiB)
```