### PR TITLE
Fix tests on nightly

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1968,7 +1968,7 @@ end
         @test parent(b) isa AbstractRange
 
         for ri in Any[2:3, Base.OneTo(2)]
-            for r in [IdentityUnitRange(ri), IdOffsetRange(ri), IdOffsetRange(ri, 1), OffsetArray(ri), OffsetArray(ri, 2)]
+            for r in Any[IdentityUnitRange(ri), IdOffsetRange(ri), IdOffsetRange(ri, 1), OffsetArray(ri), OffsetArray(ri, 2)]
                 for T in [Int8, Int16, Int32, Int64, Int128, BigInt, Float32, Float64, BigFloat]
                     r2 = map(T, r)
                     @test eltype(r2) == T


### PR DESCRIPTION
https://github.com/JuliaLang/julia/issues/44939 was leading to test failures, but this should be a `Vector{Any}` anyway 