### PR TITLE
no_offset_view in Origin

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.11.0"
+version = "1.11.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -210,8 +210,8 @@ for FT in (:OffsetArray, :OffsetVector, :OffsetMatrix)
     @eval @inline $FT(A::AbstractArray, origin::Origin; checkoverflow = true) = $FT(A, origin.index .- first.(axes(A)); checkoverflow = checkoverflow)
 end
 
-(o::Origin)(A::AbstractArray) = OffsetArray(A, o)
-Origin(A::OffsetArray) = Origin(first.(axes(A)))
+(o::Origin)(A::AbstractArray) = OffsetArray(no_offset_view(A), o)
+Origin(A::AbstractArray) = Origin(first.(axes(A)))
 
 # conversion-related methods
 @inline OffsetArray{T}(M::AbstractArray, I...; kw...) where {T} = OffsetArray{T,ndims(M)}(M, I...; kw...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2594,25 +2594,6 @@ end
 
 include("origin.jl")
 
-@testset "Origin" begin
-    @testset "as a callable" begin
-        a = [1 2; 3 4];
-        @test OffsetArray(a, Origin(2)) === Origin(2)(a)
-        for (index, firstinds) in Any[(1, (1,1)), ((2,3), (2,3))]
-            b = Origin(index)(a)
-            @test first.(axes(b)) == firstinds
-            @test Origin(b) === Origin(firstinds)
-        end
-    end
-    @testset "display" begin
-        io = IOBuffer()
-        show(io, Origin(1))
-        @test String(take!(io)) == "Origin(1)"
-        show(io, Origin(1, 1))
-        @test String(take!(io)) == "Origin(1, 1)"
-    end
-end
-
 @testset "misc" begin
     @test OffsetArrays._subtractoffset(Base.OneTo(2), 1) isa AbstractUnitRange{Int}
     @test OffsetArrays._subtractoffset(Base.OneTo(2), 1) == 0:1


### PR DESCRIPTION
Fixes #279

Also, earlier, the `Origin` constructor had only been defined for `OffsetArrays`, mistakenly, so this PR extends it to `AbstractArray`s.