### PR TITLE
Define array promotion rules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.11.2"
+version = "1.12.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -274,6 +274,16 @@ end
 end
 @inline OffsetArray{T}(init::ArrayInitializer, inds...; kw...) where {T} = OffsetArray{T}(init, inds; kw...)
 
+# promotion
+
+# return an OffsetArray if promote_type return a concrete result
+_promote(A::Type{<:AbstractArray{T,N}}) where {T,N} = OffsetArray{T,N,A}
+_promote(A::Type{<:AbstractArray}) = A
+function Base.promote_rule(A::Type{<:AbstractArray{<:Any,N}}, OA::Type{<:OffsetArray{<:Any,N,<:AbstractArray{<:Any,N}}}) where {N}
+    AB = promote_type(A, parenttype(OA))
+    _promote(AB)
+end
+
 Base.IndexStyle(::Type{OA}) where {OA<:OffsetArray} = IndexStyle(parenttype(OA))
 parenttype(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA
 parenttype(A::OffsetArray) = parenttype(typeof(A))

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -279,14 +279,14 @@ end
 # return an OffsetArray if promote_type return a concrete result
 _promote(A::Type{<:AbstractArray{T,N}}) where {T,N} = OffsetArray{T,N,A}
 # try to narrow down the type parameters, return a generic wrapper if it fails
-_promote(A::Type{<:AbstractArray{T}}) where {T} = OffsetArray{T}
+_promote(A::Type{<:AbstractArray{T}}) where {T} = OffsetArray{T,<:Any,A}
 _promote(A::Type{<:AbstractArray{<:Any,N}}) where {N} = OffsetArray{<:Any,N}
 _promote(A::Type{<:AbstractArray}) = AbstractArray
-function Base.promote_rule(A::Type{<:AbstractArray{<:Any,N}}, OA::Type{<:OffsetArray{<:Any,N,<:AbstractArray{<:Any,N}}}) where {N}
+function Base.promote_rule(A::Type{<:AbstractArray{T1,N}}, OA::Type{<:OffsetArray{T2,N,<:AbstractArray{T2,N}}}) where {T1,T2,N}
     AB = promote_type(A, parenttype(OA))
     _promote(AB)
 end
-function Base.promote_rule(OA::Type{<:OffsetArray{<:Any,N,A}}, OB::Type{<:OffsetArray{<:Any,N,B}}) where {N,A<:AbstractArray{<:Any,N},B<:AbstractArray{<:Any,N}}
+function Base.promote_rule(::Type{OffsetArray{T1,N,A}}, ::Type{OffsetArray{T2,N,B}}) where {T1,T2,N,A<:AbstractArray{T1,N},B<:AbstractArray{T2,N}}
     AB = promote_type(A, B)
     _promote(AB)
 end

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -279,8 +279,8 @@ end
 # return an OffsetArray if promote_type return a concrete result
 _promote(A::Type{<:AbstractArray{T,N}}) where {T,N} = OffsetArray{T,N,A}
 # try to narrow down the type parameters otherwise
-_promote(A::Type{<:AbstractArray{<:Any,N}}) where {N} = OffsetArray{<:Any,N}
-_promote(A::Type{<:AbstractArray{T}}) where {T} = OffsetArray{T,<:Any}
+_promote(A::Type{<:AbstractArray{<:Any,N}}) where {N} = AbstractArray{<:Any,N}
+_promote(A::Type{<:AbstractArray{T}}) where {T} = AbstractArray{T,<:Any}
 _promote(A::Type{<:AbstractArray}) = AbstractArray
 function Base.promote_rule(A::Type{<:AbstractArray{T1,N}}, OA::Type{<:OffsetArray{T2,N,<:AbstractArray{T2,N}}}) where {T1,T2,N}
     AB = promote_type(A, parenttype(OA))

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -278,9 +278,16 @@ end
 
 # return an OffsetArray if promote_type return a concrete result
 _promote(A::Type{<:AbstractArray{T,N}}) where {T,N} = OffsetArray{T,N,A}
-_promote(A::Type{<:AbstractArray}) = A
+# try to narrow down the type parameters, return a generic wrapper if it fails
+_promote(A::Type{<:AbstractArray{T}}) where {T} = OffsetArray{T}
+_promote(A::Type{<:AbstractArray{<:Any,N}}) where {N} = OffsetArray{<:Any,N}
+_promote(A::Type{<:AbstractArray}) = AbstractArray
 function Base.promote_rule(A::Type{<:AbstractArray{<:Any,N}}, OA::Type{<:OffsetArray{<:Any,N,<:AbstractArray{<:Any,N}}}) where {N}
     AB = promote_type(A, parenttype(OA))
+    _promote(AB)
+end
+function Base.promote_rule(OA::Type{<:OffsetArray{<:Any,N,A}}, OB::Type{<:OffsetArray{<:Any,N,B}}) where {N,A<:AbstractArray{<:Any,N},B<:AbstractArray{<:Any,N}}
+    AB = promote_type(A, B)
     _promote(AB)
 end
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -280,11 +280,13 @@ end
 _promote(A::Type{<:AbstractArray{T,N}}) where {T,N} = OffsetArray{T,N,A}
 # try to narrow down the type parameters otherwise
 _promote(A::Type{<:AbstractArray{<:Any,N}}) where {N} = OffsetArray{<:Any,N}
+_promote(A::Type{<:AbstractArray{T}}) where {T} = OffsetArray{T,<:Any}
+_promote(A::Type{<:AbstractArray}) = AbstractArray
 function Base.promote_rule(A::Type{<:AbstractArray{T1,N}}, OA::Type{<:OffsetArray{T2,N,<:AbstractArray{T2,N}}}) where {T1,T2,N}
     AB = promote_type(A, parenttype(OA))
     _promote(AB)
 end
-function Base.promote_rule(::Type{OffsetArray{T1,N,A}}, ::Type{OffsetArray{T2,N,B}}) where {T1,T2,N,A<:AbstractArray{T1,N},B<:AbstractArray{T2,N}}
+function Base.promote_rule(::Type{OffsetArray{T1,N1,A}}, ::Type{OffsetArray{T2,N2,B}}) where {T1,T2,N1,N2,A<:AbstractArray{T1,N1},B<:AbstractArray{T2,N2}}
     AB = promote_type(A, B)
     _promote(AB)
 end

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -278,10 +278,8 @@ end
 
 # return an OffsetArray if promote_type return a concrete result
 _promote(A::Type{<:AbstractArray{T,N}}) where {T,N} = OffsetArray{T,N,A}
-# try to narrow down the type parameters, return a generic wrapper if it fails
-_promote(A::Type{<:AbstractArray{T}}) where {T} = OffsetArray{T,<:Any,A}
+# try to narrow down the type parameters otherwise
 _promote(A::Type{<:AbstractArray{<:Any,N}}) where {N} = OffsetArray{<:Any,N}
-_promote(A::Type{<:AbstractArray}) = AbstractArray
 function Base.promote_rule(A::Type{<:AbstractArray{T1,N}}, OA::Type{<:OffsetArray{T2,N,<:AbstractArray{T2,N}}}) where {T1,T2,N}
     AB = promote_type(A, parenttype(OA))
     _promote(AB)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2424,7 +2424,7 @@ struct Bar end
     @test v isa Vector{<:AbstractVector}
 
     # preserve eltype if ndims differ
-    v = [OffsetArray(["a"]), OffsetArray(["b";;], 2, 2)]
+    v = [OffsetArray(["a"]), reshape(["b"], 2:2, 2:2)]
     @test v isa Vector{<:AbstractArray{String}}
 
     # preserve ndims if eltypes differ
@@ -2434,7 +2434,7 @@ struct Bar end
     @test v isa Vector{<:AbstractVector}
 
     # use a generic wrapper if both eltype and ndims differ
-    v = [OffsetArray(['a']), OffsetArray(["b";;], 2, 2)]
+    v = [OffsetArray(['a']), reshape(["b"], 2:2, 2:2)]
     @test v isa Vector{<:AbstractArray}
 
     a = reshape(SA[Foo()], 1, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2424,13 +2424,13 @@ struct Bar end
 
     # preserve eltype if ndims differ
     v = [OffsetArray(["a"]), OffsetArray(["b";;], 2, 2)]
-    @test v isa Vector{<:OffsetArray{String}}
+    @test v isa Vector{<:AbstractArray{String}}
 
     # preserve ndims if eltypes differ
     a = SA[Foo()]
     b = OffsetArray([Bar()], 2)
     v = [a, b]
-    @test v isa Vector{<:OffsetVector}
+    @test v isa Vector{<:AbstractVector}
 
     # use a generic wrapper if both eltype and ndims differ
     v = [OffsetArray(['a']), OffsetArray(["b";;], 2, 2)]
@@ -2449,18 +2449,18 @@ struct Bar end
     a = OffsetArray(["a"])
     b = OffsetArray([Foo()], 2)
     v = [a, b]
-    @test v isa Vector{<:OffsetVector}
+    @test v isa Vector{<:AbstractVector}
 
     a = OffsetArray(reshape(["a"], Val(2)), 2, 2)
     b = OffsetArray(reshape([Foo()], Val(2)))
     v = [a, b]
-    @test v isa Vector{<:OffsetMatrix}
+    @test v isa Vector{<:AbstractMatrix}
 
     v = [OffsetArray(["a"], 2), OffsetArray([1], 3), OffsetVector(['a'])]
-    @test v isa Vector{<:OffsetVector}
+    @test v isa Vector{<:AbstractVector}
 
     v = [["a", 'c'], OffsetArray([Foo()], 2)]
-    @test v isa Vector{<:OffsetVector}
+    @test v isa Vector{<:AbstractVector}
 end
 
 @testset "Adapt" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2393,17 +2393,18 @@ struct Foo end
 struct Bar end
 @testset "promotion in vect (#273)" begin
     # eltype promotion in numeric types
-    v1 = [ones(2), ones(2:3)]
+    # wrap the vector allocation in an ananymous function for @inferred to work
+    v1 = @inferred (() -> [ones(2), ones(2:3)])()
     @test v1 isa Vector{OffsetVector{Float64, Vector{Float64}}}
-    v1 = [ones(Int, 2), ones(2:3)]
+    v1 = @inferred (() -> [ones(Int, 2), ones(2:3)])()
     @test v1 isa Vector{OffsetVector{Float64, Vector{Float64}}}
-    v2 = [ones(2, 2), ones(2:3, 2:3)]
+    v2 = @inferred (() -> [ones(2, 2), ones(2:3, 2:3)])()
     @test v2 isa Vector{OffsetMatrix{Float64, Matrix{Float64}}}
-    v2 = [ones(2, 2), ones(Int, 2:3, 2:3)]
+    v2 = @inferred (() -> [ones(2, 2), ones(Int, 2:3, 2:3)])()
     @test v2 isa Vector{OffsetMatrix{Float64, Matrix{Float64}}}
-    v2 = [ones(ComplexF64, 2, 2), ones(Int, 2:3, 2:3)]
+    v2 = @inferred (() -> [ones(ComplexF64, 2, 2), ones(Int, 2:3, 2:3)])()
     @test v2 isa Vector{OffsetMatrix{ComplexF64, Matrix{ComplexF64}}}
-    v3 = [ones(ComplexF64, 2, 2, 1), ones(Int, 2:3, 2:3, 1:2)]
+    v3 = @inferred (() -> [ones(ComplexF64, 2, 2, 1), ones(Int, 2:3, 2:3, 1:2)])()
     @test v3 isa Vector{OffsetArray{ComplexF64, 3, Array{ComplexF64, 3}}}
 
     # non-numeric but identical eltypes
@@ -2419,8 +2420,8 @@ struct Bar end
     # mixed types
     a = 1:2
     b = ones(2)
-    v = [a, b]
-    @test v isa Vector{promote_type(typeof(a), typeof(b))}
+    v = (() -> [OffsetArray(a), OffsetArray(b, 2)])()
+    @test v isa Vector{<:AbstractVector}
 
     # preserve eltype if ndims differ
     v = [OffsetArray(["a"]), OffsetArray(["b";;], 2, 2)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2435,6 +2435,9 @@ struct Bar end
     b = OffsetArray(reshape([Foo()], Val(2)))
     v = [a, b]
     @test v isa Vector{<:OffsetMatrix}
+
+    v = [OffsetArray(["a"], 2), OffsetArray([1], 3), OffsetVector(['a'])]
+    @test v isa Vector{<:OffsetVector}
 end
 
 @testset "Adapt" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2414,17 +2414,27 @@ struct Bar end
     a = SA[Foo()]
     b = OffsetArray([Bar()], 2)
     v = [a, b]
-    @test v isa Vector{OffsetVector{Any,Vector{Any}}}
+    @test v isa Vector{<:AbstractVector}
 
     a = reshape(SA[Foo()], 1, 1)
     b = OffsetArray(reshape([Bar()], Val(2)), 2, 2)
     v = [a, b]
-    @test v isa Vector{OffsetMatrix{Any,Matrix{Any}}}
+    @test v isa Vector{<:AbstractMatrix}
 
     a = ["a"]
     b = ones(2:3, 3:4)
     v = [a, b]
     @test v isa Vector{<:AbstractArray}
+
+    a = OffsetArray(["a"])
+    b = OffsetArray([Foo()], 2)
+    v = [a, b]
+    @test v isa Vector{<:OffsetVector}
+
+    a = OffsetArray(reshape(["a"], Val(2)), 2, 2)
+    b = OffsetArray(reshape([Foo()], Val(2)))
+    v = [a, b]
+    @test v isa Vector{<:OffsetMatrix}
 end
 
 @testset "Adapt" begin


### PR DESCRIPTION
Fixes #273, but this will need to be tested extensively to avoid breakages. Better or more robust solutions are welcome!

This PR delegates the `promote_type` operation to the parent wherever possible, and wraps the `OffsetArray` type around the result.

After this:
```julia
julia> [ones(2), ones(2:3)]
2-element Vector{OffsetVector{Float64, Vector{Float64}}}:
 [1.0, 1.0]
 [1.0, 1.0]

julia> [OffsetArray(["a"], 2), OffsetArray([1], 3)]
2-element Vector{OffsetVector{T} where T}:
 ["a"]
 [1]
```