### PR TITLE
resolve reshape ambiguity to Base

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -376,9 +376,12 @@ Base.reshape(A::OffsetArray, inds::Tuple{Union{Integer,Base.OneTo},Vararg{Union{
 Base.reshape(A::OffsetArray, inds::Dims) = _reshape_nov(A, inds)
 Base.reshape(A::OffsetVector, ::Colon) = A
 Base.reshape(A::OffsetVector, ::Tuple{Colon}) = A
-Base.reshape(A::OffsetArray, ::Colon) = reshape(A, (Colon(),))
 Base.reshape(A::OffsetArray, inds::Union{Int,Colon}...) = reshape(A, inds)
 Base.reshape(A::OffsetArray, inds::Tuple{Vararg{Union{Int,Colon}}}) = _reshape_nov(A, inds)
+# The following two additional methods for Colon are added to resolve method ambiguities to
+# Base: https://github.com/JuliaLang/julia/pull/45387#issuecomment-1132859663
+Base.reshape(A::OffsetArray, inds::Colon) = reshape(parent(A), inds)
+Base.reshape(A::OffsetArray, inds::Tuple{Colon}) = reshape(parent(A), inds)
 
 # permutedims in Base does not preserve axes, and can not be fixed in a non-breaking way
 # This is a stopgap solution

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1835,6 +1835,11 @@ end
     rp = parent(r)
     @test axes(reshape(rp, 4:6), 1) == 4:6
     @test axes(reshape(r, (3,1))) == (1:3, 1:1)
+
+    # reshape with one single colon becomes a `vec`
+    A = OffsetArray(rand(4, 4), -1, -1)
+    @test reshape(A, (:, )) == vec(A)
+    @test reshape(A, :) == vec(A)
 end
 
 @testset "permutedims" begin


### PR DESCRIPTION
It's unclear to me why `detect_ambiguity` or Aqua with `using OffsetArrays` doesn't work in https://github.com/JuliaLang/julia/pull/45387#issuecomment-1132859663

But this PR resolves the ambiguitity issue so that

```julia
julia> include("test/testhelpers/OffsetArrays.jl")
Main.OffsetArrays

julia> using Test, .OffsetArrays

julia> detect_ambiguities(Core, Base; recursive=true, ambiguous_bottom=false)
Skipping Base.Filesystem.JL_O_RANDOM
Skipping Base.Filesystem.JL_O_SEQUENTIAL
Skipping Base.Filesystem.JL_O_SHORT_LIVED
Skipping Base.Filesystem.JL_O_TEMPORARY
Tuple{Method, Method}[]
```

Without this PR, it is

```julia
julia> detect_ambiguities(Core, Base; recursive=true, ambiguous_bottom=false)
Skipping Base.Filesystem.JL_O_RANDOM
Skipping Base.Filesystem.JL_O_SEQUENTIAL
Skipping Base.Filesystem.JL_O_SHORT_LIVED
Skipping Base.Filesystem.JL_O_TEMPORARY
2-element Vector{Tuple{Method, Method}}:
 (reshape(A::OffsetArray, inds::Tuple{Union{Colon, Integer, AbstractUnitRange}, Vararg{Union{Colon, Integer, AbstractUnitRange}}}) in Main.OffsetArrays at /home/jc/Documents/Julia/julia/test/testhelpers/OffsetArrays.jl:555, reshape(parent::AbstractVector, ::Tuple{Colon}) in Base at reshapedarray.jl:116)
 (reshape(A::OffsetArray, inds::Tuple{Vararg{Union{Colon, Int64}}}) in Main.OffsetArrays at /home/jc/Documents/Julia/julia/test/testhelpers/OffsetArrays.jl:564, reshape(parent::AbstractVector, ::Tuple{Colon}) in Base at reshapedarray.jl:116)
```