### PR TITLE
version limit OrdinalRange{T,T}(::IdOffsetRange)

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -139,7 +139,7 @@ end
 Base.AbstractUnitRange{T}(r::IdOffsetRange) where {T<:Integer} = IdOffsetRange{T}(r)
 
 # A version upper bound on this may be set after https://github.com/JuliaLang/julia/pull/40038 is merged
-if v"1.6" <= VERSION
+if v"1.6" <= VERSION < v"1.9.0-DEV.642"
     Base.OrdinalRange{T,T}(r::IdOffsetRange) where {T<:Integer} = IdOffsetRange{T}(r)
 end
 

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -138,7 +138,7 @@ end
 # to evaluate CartesianIndices for BigInt ranges, as their axes are also BigInt ranges
 Base.AbstractUnitRange{T}(r::IdOffsetRange) where {T<:Integer} = IdOffsetRange{T}(r)
 
-# A version upper bound on this may be set after https://github.com/JuliaLang/julia/pull/40038 is merged
+# https://github.com/JuliaLang/julia/pull/40038
 if v"1.6" <= VERSION < v"1.9.0-DEV.642"
     Base.OrdinalRange{T,T}(r::IdOffsetRange) where {T<:Integer} = IdOffsetRange{T}(r)
 end


### PR DESCRIPTION
This has now been incorporated into `Base`, and may be version limited here