### PR TITLE
_unsafe_wrap: Allow ind NTuple to have mixed AbstractUnitRanges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.0"
+version = "1.12.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -654,20 +654,6 @@ end
 # Avoid ambiguity
 @inline function Base.unsafe_wrap(::OffsetArrayUnion{T,N}, pointer::Ptr{T}, inds::Vararg{<:Integer,N}; kw...) where {T,N}
     _unsafe_wrap(pointer, inds; kw...)
-=======
-# Avoid ambiguity
-@inline function Base.unsafe_wrap(::Union{Type{OffsetArray}, Type{OffsetArray{T}}, Type{OffsetArray{T,N}}, Type{OffsetArray{T1, N} where T1}}, pointer::Ptr{T}, inds::NTuple{N, <:Integer}; own = false, kw...) where {T,N}
-    _checkindices(N, inds, "indices")
-    AA = Base.unsafe_wrap(Array, pointer, map(_indexlength, inds); own=own)
-    OffsetArray{T, N, typeof(AA)}(AA, map(_indexoffset, inds); kw...)
-end
-@inline function Base.unsafe_wrap(::Union{Type{OffsetArray}, Type{OffsetArray{T}}, Type{OffsetArray{T,N}}, Type{OffsetArray{T1, N} where T1}}, pointer::Ptr{T}, inds::Vararg{OffsetAxisKnownLength,N}; own = false, kw...) where {T,N}
-    unsafe_wrap(OffsetArray{T,N}, pointer, inds; own=own, kw...)
-end
-# Avoid ambiguity
-@inline function Base.unsafe_wrap(::Union{Type{OffsetArray}, Type{OffsetArray{T}}, Type{OffsetArray{T,N}}, Type{OffsetArray{T1, N} where T1}}, pointer::Ptr{T}, inds::Vararg{<:Integer,N}; own = false, kw...) where {T,N}
-    unsafe_wrap(OffsetArray{T,N}, pointer, inds; own=own, kw...)
->>>>>>> b143212 (Implement Base.unsafe_wrap for OffsetArrays)
 end
 
 """

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -626,7 +626,7 @@ function Base.replace_in_print_matrix(A::OffsetArray{<:Any,1}, i::Integer, j::In
 end
 
 # Actual unsafe_wrap implementation
-@inline function _unsafe_wrap(pointer::Ptr{T}, inds::NTuple{N}; own = false, kw...) where {T,N}
+@inline function _unsafe_wrap(pointer::Ptr{T}, inds::NTuple{N, OffsetAxisKnownLength}; own = false, kw...) where {T,N}
     _checkindices(N, inds, "indices")
     AA = Base.unsafe_wrap(Array, pointer, map(_indexlength, inds); own=own)
     OffsetArray{T, N, typeof(AA)}(AA, map(_indexoffset, inds); kw...)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -654,6 +654,20 @@ end
 # Avoid ambiguity
 @inline function Base.unsafe_wrap(::OffsetArrayUnion{T,N}, pointer::Ptr{T}, inds::Vararg{<:Integer,N}; kw...) where {T,N}
     _unsafe_wrap(pointer, inds; kw...)
+=======
+# Avoid ambiguity
+@inline function Base.unsafe_wrap(::Union{Type{OffsetArray}, Type{OffsetArray{T}}, Type{OffsetArray{T,N}}, Type{OffsetArray{T1, N} where T1}}, pointer::Ptr{T}, inds::NTuple{N, <:Integer}; own = false, kw...) where {T,N}
+    _checkindices(N, inds, "indices")
+    AA = Base.unsafe_wrap(Array, pointer, map(_indexlength, inds); own=own)
+    OffsetArray{T, N, typeof(AA)}(AA, map(_indexoffset, inds); kw...)
+end
+@inline function Base.unsafe_wrap(::Union{Type{OffsetArray}, Type{OffsetArray{T}}, Type{OffsetArray{T,N}}, Type{OffsetArray{T1, N} where T1}}, pointer::Ptr{T}, inds::Vararg{OffsetAxisKnownLength,N}; own = false, kw...) where {T,N}
+    unsafe_wrap(OffsetArray{T,N}, pointer, inds; own=own, kw...)
+end
+# Avoid ambiguity
+@inline function Base.unsafe_wrap(::Union{Type{OffsetArray}, Type{OffsetArray{T}}, Type{OffsetArray{T,N}}, Type{OffsetArray{T1, N} where T1}}, pointer::Ptr{T}, inds::Vararg{<:Integer,N}; own = false, kw...) where {T,N}
+    unsafe_wrap(OffsetArray{T,N}, pointer, inds; own=own, kw...)
+>>>>>>> b143212 (Implement Base.unsafe_wrap for OffsetArrays)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2678,11 +2678,6 @@ include("origin.jl")
     @test OffsetArrays._addoffset(3:2:9, 1) == 4:2:10
 end
 
-@info "Following deprecations are expected"
-@testset "deprecations" begin
-    A = reshape(collect(1:9), 3, 3)
-    @test OffsetArrays.centered(A, RoundDown) == OffsetArrays.centered(A, RoundUp)
-end
 @testset "unsafe_wrap" begin
     p = Ptr{UInt16}(Libc.malloc(2*3*4*2))
     @test unsafe_wrap(OffsetArray, p, 2, 3, 4) isa OffsetArray{UInt16, 3}
@@ -2698,4 +2693,11 @@ end
     @test unsafe_wrap(OffsetArray, p, (2:3, 3:5, 4:7)) isa OffsetArray{UInt8, 3}
     @test unsafe_wrap(OffsetVector, p, 1:(2*3*4) .- 1) isa OffsetVector{UInt8}
     @test unsafe_wrap(OffsetMatrix, p, 1:(2*3) .+ 6, 4:7; own = true) isa OffsetMatrix{UInt8}
+    @test unsafe_wrap(OffsetMatrix, p, -5:5, Base.OneTo(3); own = true) isa OffsetMatrix{UInt8}
+end
+
+@info "Following deprecations are expected"
+@testset "deprecations" begin
+    A = reshape(collect(1:9), 3, 3)
+    @test OffsetArrays.centered(A, RoundDown) == OffsetArrays.centered(A, RoundUp)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2692,7 +2692,7 @@ end
     @test unsafe_wrap(OffsetArray, p, 2:3, 3:5, 4:7) isa OffsetArray{UInt8, 3}
     @test unsafe_wrap(OffsetArray, p, (2:3, 3:5, 4:7)) isa OffsetArray{UInt8, 3}
     @test unsafe_wrap(OffsetVector, p, 1:(2*3*4) .- 1) isa OffsetVector{UInt8}
-    @test unsafe_wrap(OffsetMatrix, p, 1:(2*3) .+ 6, 4:7; own = true) isa OffsetMatrix{UInt8}
+    @test unsafe_wrap(OffsetMatrix, p, 1:(2*3) .+ 6, 4:7) isa OffsetMatrix{UInt8}
     @test unsafe_wrap(OffsetMatrix, p, -5:5, Base.OneTo(3); own = true) isa OffsetMatrix{UInt8}
 end
 


### PR DESCRIPTION
master:
```julia
julia> using OffsetArrays

julia> unsafe_wrap(OffsetArray{Int}, Ptr{Int}(Libc.malloc(7*11*8)), -3:3, -5:5);

julia> unsafe_wrap(OffsetArray{Int}, Ptr{Int}(Libc.malloc(7*11*8)), -3:3, Base.OneTo(5));
ERROR: MethodError: no method matching _unsafe_wrap(::Ptr{Int64}, ::Tuple{UnitRange{Int64}, Base.OneTo{Int64}})
Closest candidates are:
  _unsafe_wrap(::Ptr{T}, ::Tuple{Vararg{T, N}} where T; own, kw...) where {T, N} at ~/.julia/dev/OffsetArrays/src/OffsetArrays.jl:629
```

This pull request
```julia
julia> using OffsetArrays

julia> unsafe_wrap(OffsetArray{Int}, Ptr{Int}(Libc.malloc(7*11*8)), -3:3, -5:5);

julia> unsafe_wrap(OffsetArray{Int}, Ptr{Int}(Libc.malloc(7*11*8)), -3:3, Base.OneTo(5));
```

This normalizes `unsafe_wrap` to take similar arguments as the constructors.