### PR TITLE
Replace `round` with `div`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.2"
+version = "1.12.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -705,6 +705,13 @@ _no_offset_view(::Any, A::AbstractUnitRange) = UnitRange(A)
 # These two helpers are deliberately not exported; their meaning can be very different in
 # other scenarios and will be very likely to cause name conflicts if exported.
 #####
+
+if VERSION < v"1.4"
+   _halfroundInt(v, r::RoundingMode) = round(Int, v/2, r)
+else
+   _halfroundInt(v, r::RoundingMode) = div(v, 2, r)
+end
+
 """
     center(A, [r::RoundingMode=RoundDown])::Dims
 
@@ -743,7 +750,7 @@ can use [`centered`](@ref OffsetArrays.centered).
 """
 function center(A::AbstractArray, r::RoundingMode=RoundDown)
     map(axes(A)) do inds
-        round(Int, (length(inds)-1)/2, r) + first(inds)
+        _halfroundInt(length(inds)-1, r) + first(inds)
     end
 end
 


### PR DESCRIPTION
Minor change: isn't it probably better to use integer division `div` instead of rounding the floating point result?

It should be equivalent in common cases, more correct in extreme cases, and faster.

Regarding correctness in extreme cases, one has for instance
```julia
julia> len = 4Int(maxintfloat()) + 3
36028797018963971

julia> round(Int, (len-1)/2, RoundDown)
18014398509481984

julia> div(len-1, 2, RoundDown)
18014398509481985
```