### PR TITLE
Fix IdOffsetRange kwargs constructor given offset ranges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.3"
+version = "1.12.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -129,7 +129,7 @@ IdOffsetRange(r::IdOffsetRange) = r
 
 # Constructor to make `show` round-trippable
 # try to preserve typeof(values) if the indices are known to be 1-based
-_subtractindexoffset(values, indices::Base.OneTo, offset) = values
+_subtractindexoffset(values, indices::Union{Base.OneTo, IdentityUnitRange{<:Base.OneTo}}, offset) = values
 _subtractindexoffset(values, indices, offset) = _subtractoffset(values, offset)
 function IdOffsetRange(; values::AbstractUnitRange{<:Integer}, indices::AbstractUnitRange{<:Integer})
     length(values) == length(indices) || throw(ArgumentError("values and indices must have the same length"))

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -128,10 +128,13 @@ end
 IdOffsetRange(r::IdOffsetRange) = r
 
 # Constructor to make `show` round-trippable
+# try to preserve typeof(values) if the indices are known to be 1-based
+_subtractindexoffset(values, indices::Base.OneTo, offset) = values
+_subtractindexoffset(values, indices, offset) = _subtractoffset(values, offset)
 function IdOffsetRange(; values::AbstractUnitRange{<:Integer}, indices::AbstractUnitRange{<:Integer})
     length(values) == length(indices) || throw(ArgumentError("values and indices must have the same length"))
     offset = first(indices) - 1
-    return IdOffsetRange(_subtractoffset(values, offset), offset)
+    return IdOffsetRange(_subtractindexoffset(values, indices, offset), offset)
 end
 
 # Conversions to an AbstractUnitRange{Int} (and to an OrdinalRange{Int,Int} on Julia v"1.6") are necessary

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -133,8 +133,10 @@ _subtractindexoffset(values, indices::Base.OneTo, offset) = values
 _subtractindexoffset(values, indices, offset) = _subtractoffset(values, offset)
 function IdOffsetRange(; values::AbstractUnitRange{<:Integer}, indices::AbstractUnitRange{<:Integer})
     length(values) == length(indices) || throw(ArgumentError("values and indices must have the same length"))
+    values_nooffset = no_offset_view(values)
     offset = first(indices) - 1
-    return IdOffsetRange(_subtractindexoffset(values, indices, offset), offset)
+    values_minus_offset = _subtractindexoffset(values_nooffset, indices, offset)
+    return IdOffsetRange(values_minus_offset, offset)
 end
 
 # Conversions to an AbstractUnitRange{Int} (and to an OrdinalRange{Int,Int} on Julia v"1.6") are necessary

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -131,7 +131,7 @@ IdOffsetRange(r::IdOffsetRange) = r
 function IdOffsetRange(; values::AbstractUnitRange{<:Integer}, indices::AbstractUnitRange{<:Integer})
     length(values) == length(indices) || throw(ArgumentError("values and indices must have the same length"))
     offset = first(indices) - 1
-    return IdOffsetRange(values .- offset, offset)
+    return IdOffsetRange(_subtractoffset(values, offset), offset)
 end
 
 # Conversions to an AbstractUnitRange{Int} (and to an OrdinalRange{Int,Int} on Julia v"1.6") are necessary

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,6 +138,11 @@ end
     @test_throws MethodError IdOffsetRange(7:9, indices=-1:1)
     @test_throws MethodError IdOffsetRange(-1:1, values=7:9)
 
+    p = IdOffsetRange(1:3, 2)
+    q = IdOffsetRange(values = p .- 2, indices = p)
+    @test same_value(q, 1:3)
+    check_indexed_by(q, p)
+
     # conversion preserves both the values and the axes, throwing an error if this is not possible
     @test @inferred(oftype(ro, ro)) === ro
     @test @inferred(convert(OffsetArrays.IdOffsetRange{Int}, ro)) === ro

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,6 +143,11 @@ end
     @test same_value(q, 1:3)
     check_indexed_by(q, p)
 
+    p = IdOffsetRange(values = Base.OneTo(2), indices = Base.OneTo(2))
+    @test p isa IdOffsetRange{Int, Base.OneTo{Int}}
+    p = IdOffsetRange(values = SOneTo(2), indices = Base.OneTo(2))
+    @test p isa IdOffsetRange{Int, SOneTo{2}}
+
     # conversion preserves both the values and the axes, throwing an error if this is not possible
     @test @inferred(oftype(ro, ro)) === ro
     @test @inferred(convert(OffsetArrays.IdOffsetRange{Int}, ro)) === ro

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,12 +143,14 @@ end
     @test same_value(q, 1:3)
     check_indexed_by(q, p)
 
-    p = IdOffsetRange(values = IdOffsetRange(1:3, 2), indices = Base.OneTo(3))
-    @test same_value(p, 3:5)
-    check_indexed_by(p, 1:3)
-
-    p = IdOffsetRange(values = Base.OneTo(2), indices = Base.OneTo(2))
-    @test p isa IdOffsetRange{Int, Base.OneTo{Int}}
+    @testset for indices in Any[Base.OneTo(3), IdentityUnitRange(Base.OneTo(3))]
+        p = IdOffsetRange(values = IdOffsetRange(1:3, 2), indices = indices)
+        @test same_value(p, 3:5)
+        check_indexed_by(p, 1:3)
+        q = IdOffsetRange(values = Base.OneTo(3), indices = indices)
+        @test same_value(q, 1:3)
+        @test q isa IdOffsetRange{Int, Base.OneTo{Int}}
+    end
 
     # conversion preserves both the values and the axes, throwing an error if this is not possible
     @test @inferred(oftype(ro, ro)) === ro

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,6 +143,10 @@ end
     @test same_value(q, 1:3)
     check_indexed_by(q, p)
 
+    p = IdOffsetRange(values = IdOffsetRange(1:3, 2), indices = Base.OneTo(3))
+    @test same_value(p, 3:5)
+    check_indexed_by(p, 1:3)
+
     p = IdOffsetRange(values = Base.OneTo(2), indices = Base.OneTo(2))
     @test p isa IdOffsetRange{Int, Base.OneTo{Int}}
     p = IdOffsetRange(values = SOneTo(2), indices = Base.OneTo(2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -149,8 +149,6 @@ end
 
     p = IdOffsetRange(values = Base.OneTo(2), indices = Base.OneTo(2))
     @test p isa IdOffsetRange{Int, Base.OneTo{Int}}
-    p = IdOffsetRange(values = SOneTo(2), indices = Base.OneTo(2))
-    @test p isa IdOffsetRange{Int, SOneTo{2}}
 
     # conversion preserves both the values and the axes, throwing an error if this is not possible
     @test @inferred(oftype(ro, ro)) === ro


### PR DESCRIPTION
On master
```julia
julia> import OffsetArrays: IdOffsetRange

julia> p = OffsetArrays.IdOffsetRange(1:3, 2)
IdOffsetRange(values=3:5, indices=3:5)

julia> IdOffsetRange(values=p.-2, indices=p)
IdOffsetRange(values=1:3, indices=5:7)
```
The issue here is that `p .- 2` preserves its axes on broadcasting. May be fixed easily by stripping the axes.

After this PR
```julia
julia> IdOffsetRange(values=p.-2, indices=p)
IdOffsetRange(values=1:3, indices=3:5)
```