### PR TITLE
Forward length to parent

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -287,6 +287,7 @@ Base.parent(A::OffsetArray) = A.parent
 # Base.Broadcast.BroadcastStyle(::Type{<:OffsetArray{<:Any, <:Any, AA}}) where AA = Base.Broadcast.BroadcastStyle(AA)
 
 @inline Base.size(A::OffsetArray) = size(parent(A))
+@inline Base.length(A::OffsetArray) = length(parent(A))
 
 @inline Base.axes(A::OffsetArray) = map(IdOffsetRange, axes(parent(A)), A.offsets)
 @inline Base.axes(A::OffsetArray, d) = d <= ndims(A) ? IdOffsetRange(axes(parent(A), d), A.offsets[d]) : IdOffsetRange(axes(parent(A), d))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -907,6 +907,18 @@ Base.Int(a::WeirdInteger) = a
             @test axes(y) == (r, )
         end
     end
+
+    @testset "size/length" begin
+        for p in Any[SA[1,2,3,4], 1:4, [1:4;]]
+            for A in Any[OffsetArray(p, 4),
+                    OffsetArray(reshape(p, 2, 2), 3, 4),
+                    OffsetArray(reshape(p, 2, 1, 2), 3, 0, 4),
+                    OffsetArray(reshape(p, Val(1)), 2)]
+                @test size(A) == size(parent(A))
+                @test length(A) == length(parent(A))
+            end
+        end
+    end
 end
 
 @testset "Axes supplied to constructor correspond to final result" begin


### PR DESCRIPTION
This might lead to simpler code, especially if the length of the parent is easy to compute without evaluating a product (e.g. for `StaticArray`s where it is known at compile time, and may be constant-propagated).

On nightly with this PR
```julia
julia> A = OffsetArray(reshape(SA[1,2,3,4],2,2), 3, 4)
2×2 OffsetArray(reshape(::SVector{4, Int64}, 2, 2), 4:5, 5:6) with eltype Int64 with indices 4:5×5:6:
 1  3
 2  4

julia> @code_typed length(A)
CodeInfo(
1 ─     return 4
) => Int64
```