### PR TITLE
Avoid accidental piracy in `Base.inds2string`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.6"
+version = "1.12.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -605,7 +605,8 @@ Base.append!(A::OffsetVector, items) = (append!(A.parent, items); A)
 Base.empty!(A::OffsetVector) = (empty!(A.parent); A)
 
 # These functions keep the summary compact
-function Base.inds2string(inds::Tuple{Vararg{Union{IdOffsetRange, IdentityUnitRange{<:IdOffsetRange}}}})
+const OffsetIndices = Union{IdOffsetRange, IdentityUnitRange{<:IdOffsetRange}}
+function Base.inds2string(inds::Tuple{OffsetIndices, Vararg{OffsetIndices}})
     Base.inds2string(map(UnitRange, inds))
 end
 Base.showindices(io::IO, ind1::IdOffsetRange, inds::IdOffsetRange...) = Base.showindices(io, map(UnitRange, (ind1, inds...))...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1593,6 +1593,10 @@ end
     @test pairs(rrtable) == pairs(rrted)
 
     @test Base.inds2string(axes(a)) == Base.inds2string(map(UnitRange, axes(a)))
+    @test Base.inds2string((IdOffsetRange(3:4),)) == "3:4"
+    @test Base.inds2string((IdentityUnitRange(IdOffsetRange(3:4)),)) == "3:4"
+    # check that the following doesn't throw
+    @test Base.inds2string(()) isa Any
 
     show(io, OffsetArray(3:5, 0:2))
     @test String(take!(io)) == "3:5 with indices 0:2"


### PR DESCRIPTION
This fixes a `StackOverflowError` on master
Master:
```julia
julia> Base.inds2string(())
ERROR: StackOverflowError:
```
Now
```julia
julia> Base.inds2string(())
""
```