### PR TITLE
Invalidation check on a stable version

### DIFF
--- a/.github/workflows/invalidations.yml
+++ b/.github/workflows/invalidations.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v1
       with:
-        version: 'nightly'
+        version: '1'
     - uses: actions/checkout@v2
     - uses: julia-actions/julia-buildpkg@latest
     - uses: julia-actions/julia-invalidations@v1


### PR DESCRIPTION
Instead of testing on nightly, which can be unstable, test on a stable julia version. See https://github.com/JuliaArrays/OffsetArrays.jl/runs/8170445402?check_suite_focus=true for a case where the test fails on nightly because of "unreachable reached"