### PR TITLE
Reduce invalidation by not specializing lastindex/axes1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.7"
+version = "1.12.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -188,8 +188,10 @@ end
 Base.reduced_index(i::IdOffsetRange) = typeof(i)(first(i):first(i))
 # Workaround for #92 on Julia < 1.4
 Base.reduced_index(i::IdentityUnitRange{<:IdOffsetRange}) = typeof(i)(first(i):first(i))
-for f in [:firstindex, :lastindex]
-    @eval @inline Base.$f(r::IdOffsetRange) = $f(r.parent) + r.offset
+if VERSION < v"1.8.2"
+    for f in [:firstindex, :lastindex]
+        @eval @inline Base.$f(r::IdOffsetRange) = $f(r.parent) + r.offset
+    end
 end
 for f in [:first, :last]
     # coerce the type to deal with values that get promoted on addition (eg. Bool)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -170,9 +170,12 @@ offset_coerce(::Type{I}, r::AbstractUnitRange) where I<:AbstractUnitRange =
     convert(I, r)::I, 0
 
 @inline Base.parent(r::IdOffsetRange) = r.parent
-@inline Base.axes(r::IdOffsetRange) = (Base.axes1(r),)
-@inline Base.axes1(r::IdOffsetRange) = IdOffsetRange(Base.axes1(r.parent), r.offset)
-@inline Base.unsafe_indices(r::IdOffsetRange) = (Base.axes1(r),)
+@inline Base.axes(r::IdOffsetRange) = (axes1(r),)
+@inline axes1(r::IdOffsetRange) = IdOffsetRange(Base.axes1(r.parent), r.offset)
+if VERSION < v"1.8.2"
+    Base.axes1(r::IdOffsetRange) = axes1(r)
+end
+@inline Base.unsafe_indices(r::IdOffsetRange) = (axes1(r),)
 @inline Base.length(r::IdOffsetRange) = length(r.parent)
 @inline Base.isempty(r::IdOffsetRange) = isempty(r.parent)
 #= We specialize on reduced_indices to work around cases where the parent axis type doesn't


### PR DESCRIPTION
I don't see any speedup from specializing these on recent Julia versions, and this PR reduces invalidation.
On master (Julia v1.8.2)
```julia
julia> r = OffsetArrays.IdOffsetRange(3:10000);

julia> @btime firstindex($(Ref(r))[]);
  2.935 ns (0 allocations: 0 bytes)

julia> @btime lastindex($(Ref(r))[]);
  3.354 ns (0 allocations: 0 bytes)
```
This PR
```julia
julia> @btime firstindex($(Ref(r))[]);
  2.935 ns (0 allocations: 0 bytes)

julia> @btime lastindex($(Ref(r))[]);
  2.942 ns (0 allocations: 0 bytes)
```

Similarly, for `axes1`. On Julia v1.9, and using the master branch for OffsetArrays:
```julia
julia> using SnoopCompileCore

julia> invalidations = @snoopr using OffsetArrays;

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
3-element Vector{SnoopCompile.MethodInvalidations}:
 inserting similar(::Type{T}, shape::Tuple{Union{Integer, AbstractUnitRange}, Vararg{Union{Integer, AbstractUnitRange}}}) where T<:AbstractArray @ OffsetArrays ~/Dropbox/JuliaPackages/OffsetArrays.jl/src/OffsetArrays.jl:331 invalidated:
   mt_backedges: 1: signature Tuple{typeof(similar), Type{Array{Union{Int64, Symbol}, _A}} where _A, Tuple{Union{Integer, AbstractUnitRange}}} triggered MethodInstance for similar(::Type{Array{Union{Int64, Symbol}, _A}}, ::Union{Integer, AbstractUnitRange}) where _A (0 children)
                 2: signature Tuple{typeof(similar), Type{Array{Base.PkgId, _A}} where _A, Tuple{Union{Integer, AbstractUnitRange}}} triggered MethodInstance for similar(::Type{Array{Base.PkgId, _A}}, ::Union{Integer, AbstractUnitRange}) where _A (0 children)

 inserting lastindex(r::OffsetArrays.IdOffsetRange) @ OffsetArrays ~/Dropbox/JuliaPackages/OffsetArrays.jl/src/axes.jl:192 invalidated:
   backedges: 1: superseding lastindex(a::AbstractArray) @ Base abstractarray.jl:411 with MethodInstance for lastindex(::AbstractVector) (4 children)
   3 mt_cache

 inserting axes1(r::OffsetArrays.IdOffsetRange) @ OffsetArrays ~/Dropbox/JuliaPackages/OffsetArrays.jl/src/axes.jl:174 invalidated:
   backedges: 1: superseding axes1(A::AbstractArray) @ Base abstractarray.jl:133 with MethodInstance for Base.axes1(::AbstractVector{UInt8}) (37 children)
```
This PR
```julia
julia> trees = invalidation_trees(invalidations)
1-element Vector{SnoopCompile.MethodInvalidations}:
 inserting similar(::Type{T}, shape::Tuple{Union{Integer, AbstractUnitRange}, Vararg{Union{Integer, AbstractUnitRange}}}) where T<:AbstractArray @ OffsetArrays ~/Dropbox/JuliaPackages/OffsetArrays.jl/src/OffsetArrays.jl:331 invalidated:
   mt_backedges: 1: signature Tuple{typeof(similar), Type{Array{Union{Int64, Symbol}, _A}} where _A, Tuple{Union{Integer, AbstractUnitRange}}} triggered MethodInstance for similar(::Type{Array{Union{Int64, Symbol}, _A}}, ::Union{Integer, AbstractUnitRange}) where _A (0 children)
                 2: signature Tuple{typeof(similar), Type{Array{Base.PkgId, _A}} where _A, Tuple{Union{Integer, AbstractUnitRange}}} triggered MethodInstance for similar(::Type{Array{Base.PkgId, _A}}, ::Union{Integer, AbstractUnitRange}) where _A (0 children)
```