### PR TITLE
Update checkout action to v3 in CI

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -36,7 +36,7 @@ jobs:
             julia-arch: x86
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v3
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:


### PR DESCRIPTION
Copied from https://github.com/actions/checkout, hopefully it'll get around the outdated node.js12 jobs warning