### PR TITLE
fix deprecated syntax: Wrapping Vararg directly in UnionAll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.8"
+version = "1.12.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -657,7 +657,7 @@ end
     _unsafe_wrap(pointer, inds; kw...)
 end
 # Avoid ambiguity
-@inline function Base.unsafe_wrap(::OffsetArrayUnion{T,N}, pointer::Ptr{T}, inds::Vararg{<:Integer,N}; kw...) where {T,N}
+@inline function Base.unsafe_wrap(::OffsetArrayUnion{T,N}, pointer::Ptr{T}, inds::Vararg{Integer,N}; kw...) where {T,N}
     _unsafe_wrap(pointer, inds; kw...)
 end
 


### PR DESCRIPTION
Syntax like this seems to be deprecated: `inds::Vararg{<:Integer,N}`, so I removed the `<:`.

```
$ julia -O3 --min-optlevel=3 --depwarn=error --warn-overwrite=yes
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.10.0-DEV.453 (2023-01-28)
 _/ |\__'_|_|_|\__'_|  |  Commit 7d4309c9c31 (0 days old master)
|__/                   |

julia> using OffsetArrays
[ Info: Precompiling OffsetArrays [6fe1bfb0-de20-5000-8ca7-80f57d26f881]
ERROR: LoadError: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
Stacktrace:
 [1] UnionAll(v::TypeVar, t::Any)
   @ Core ./boot.jl:257
 [2] top-level scope
   @ ~/tmp/OffsetArrays.jl/src/OffsetArrays.jl:660
```

Fixes #324 