### PR TITLE
Use Aqua v0.6 in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 
 [compat]
 Adapt = "2, 3"
-Aqua = "0.5"
+Aqua = "0.6"
 CatIndices = "0.2"
 DistributedArrays = "0.6"
 Documenter = "0.27"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -13,7 +13,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Adapt = "2, 3"
-Aqua = "0.5"
+Aqua = "0.6"
 CatIndices = "0.2"
 DistributedArrays = "0.6"
 Documenter = "0.27"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,8 +41,7 @@ function same_value(r1, r2)
 end
 
 @testset "Project meta quality checks" begin
-    # Not checking compat section for test-only dependencies
-    Aqua.test_all(OffsetArrays; project_extras=true, deps_compat=true, stale_deps=true, project_toml_formatting=true)
+    Aqua.test_all(OffsetArrays, piracy=false)
     if VERSION >= v"1.2"
         doctest(OffsetArrays, manual = false)
     end


### PR DESCRIPTION
Since Aqua v0.5 is not being maintained anymore, it's worth switching to v0.6, which will receive fixes for the latest Julia features.