### PR TITLE
Implement a default offset option for all higher dimensions, to support a more complete `centered`

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -205,7 +205,7 @@ for FT in (:OffsetArray, :OffsetVector, :OffsetMatrix)
         $FT(A, map(_offset, axes(A), inds); kw...)
     end
 
-    @eval @inline $FT(A::AbstractArray, inds...; kw...) = $FT(A, inds...; kw...)
+    @eval @inline $FT(A::AbstractArray, inds...; kw...) = $FT(A, inds; kw...)
     @eval @inline $FT(A::AbstractArray; checkoverflow = false) = $FT(A, ntuple(zero, Val(ndims(A))), checkoverflow = checkoverflow)
 
     @eval @inline $FT(A::AbstractArray, origin::Origin; checkoverflow = true) = $FT(A, origin.index .- first.(axes(A)); checkoverflow = checkoverflow)
@@ -226,7 +226,7 @@ end
 
 @inline OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I...; kw...) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(M, I; kw...)
 @inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::NTuple{N,Int}; checkoverflow = true) where {T,N,A<:AbstractArray{T,N}}
-    checkoverflow && map(overflow_check, axes(M), I...)
+    checkoverflow && map(overflow_check, axes(M), I)
     Mv = no_offset_view(M)
     MvA = convert(A, Mv)::A
     Iof = map(+, _offsets(M), I)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -850,7 +850,7 @@ if VERSION <= v"1.7.0-DEV.400"
     Base._to_linear_index(A::OffsetArray) = first(LinearIndices(A))
 end
 
-Base.has_offset_axes(A::OffsetArray) = any(!=(0), A.offsets) | A.default_offset != 0
+Base.has_offset_axes(A::OffsetArray) = any(!=(0), A.offsets) || A.default_offset != 0
 
 ##
 # Adapt allows for automatic conversion of CPU OffsetArrays to GPU OffsetArrays

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -850,6 +850,8 @@ if VERSION <= v"1.7.0-DEV.400"
     Base._to_linear_index(A::OffsetArray) = first(LinearIndices(A))
 end
 
+Base.has_offset_axes(A::OffsetArray) = any(!=(0), A.offsets) | A.default_offset != 0
+
 ##
 # Adapt allows for automatic conversion of CPU OffsetArrays to GPU OffsetArrays
 ##

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -293,3 +293,5 @@ end
 # if isdefined(Base, :_firstslice)
 #     Base._firstslice(i::IdOffsetRange) = IdOffsetRange(Base._firstslice(i.parent), i.offset)
 # end
+
+Base.has_offset_axes(A::OffsetArray) = any(!=(0), A.offsets) | A.default_offset != 0

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -293,5 +293,3 @@ end
 # if isdefined(Base, :_firstslice)
 #     Base._firstslice(i::IdOffsetRange) = IdOffsetRange(Base._firstslice(i.parent), i.offset)
 # end
-
-Base.has_offset_axes(A::OffsetArray) = any(!=(0), A.offsets) | A.default_offset != 0


### PR DESCRIPTION
Fixes #339 , but requires support from Julia Base to call the right `axes` methods. The API for this is probably not right, and obviously needs tests and docs. But would like feedback first.