### PR TITLE
Cancel concurrent tests

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -18,6 +18,10 @@ on:
   schedule:
     - cron: '20 00 1 * *'
 
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This should make PR tests run faster if commits are pushed in quick succession