### PR TITLE
Remove explicit test on v1.10

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -30,7 +30,7 @@ jobs:
       # https://github.com/actions/toolkit/issues/399
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1.6', '1', '~1.10.0-0', 'nightly']
+        julia-version: ['1.0', '1.6', '1', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
         julia-arch: [x64]
         # only test one 32-bit job


### PR DESCRIPTION
This is redundant now as v1 points to v1.10