### PR TITLE
Version-limit zeros/ones/fill/trues/falses

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -391,16 +391,18 @@ Base.reshape(A::OffsetArray, inds::Tuple{Colon}) = reshape(parent(A), inds)
 # This is a stopgap solution
 Base.permutedims(v::OffsetVector) = reshape(v, (1, axes(v, 1)))
 
-Base.fill(v, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-    fill!(similar(Array{typeof(v)}, inds), v)
-Base.zeros(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
-    fill!(similar(Array{T}, inds), zero(T))
-Base.ones(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
-    fill!(similar(Array{T}, inds), one(T))
-Base.trues(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-    fill!(similar(BitArray, inds), true)
-Base.falses(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
-    fill!(similar(BitArray, inds), false)
+if VERSION < v"1.12.0-DEV.343" # available in Base beyond this version
+    Base.fill(v, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
+        fill!(similar(Array{typeof(v)}, inds), v)
+    Base.zeros(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
+        fill!(similar(Array{T}, inds), zero(T))
+    Base.ones(::Type{T}, inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {T, N} =
+        fill!(similar(Array{T}, inds), one(T))
+    Base.trues(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
+        fill!(similar(BitArray, inds), true)
+    Base.falses(inds::NTuple{N, Union{Integer, AbstractUnitRange}}) where {N} =
+        fill!(similar(BitArray, inds), false)
+end
 
 Base.zero(A::OffsetArray) = parent_call(zero, A)
 Base.fill!(A::OffsetArray, x) = parent_call(Ap -> fill!(Ap, x), A)


### PR DESCRIPTION
These are now available in `Base` after https://github.com/JuliaLang/julia/pull/53965, so we don't need to commit type-piracy in this package.