### PR TITLE
Test against LTS and prerelease versions

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -30,7 +30,7 @@ jobs:
       # https://github.com/actions/toolkit/issues/399
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1.6', '1', 'nightly']
+        julia-version: ['1.0', 'lts', '1', 'pre']
         os: [ubuntu-latest, windows-latest, macOS-latest]
         julia-arch: [x64]
         # only test one 32-bit job
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@v2.2
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}


### PR DESCRIPTION
This changes the nightly test to prerelease versions, and updates the test against v1.6 to the latest LTS version. This now uses setup-julia v2.2 to avail the LTS and pre versions.