### PR TITLE
Test OffsetArray sums using Integer-valued parents

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2053,7 +2053,7 @@ end
 end
 
 @testset "reductions" begin
-    A = OffsetArray(rand(4,4), (-3,5))
+    A = OffsetArray(rand(Int,4,4), (-3,5))
     @test maximum(A) == maximum(parent(A))
     @test minimum(A) == minimum(parent(A))
     @test extrema(A) == extrema(parent(A))


### PR DESCRIPTION
There are some non-deterministic test failures related to floating-point precision in summing over `OffsetArray`s, perhaps arising from simd on some platforms. These tests do not require floating-point arrays, so we may use integer ones instead and ensure that the values are exactly comparable.