### PR TITLE
Run the invalidations CI job on julia v1.10

### DIFF
--- a/.github/workflows/invalidations.yml
+++ b/.github/workflows/invalidations.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v2
       with:
-        version: '1'
+        version: '1.10'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@latest
     - uses: julia-actions/julia-invalidations@v1

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Manifest.toml
 Manifest-v*.*.toml
 docs/build
 LocalPreferences.toml
+.vscode


### PR DESCRIPTION
This currently fetches dependencies that are incompatible with julia v1.11, and the job fails at precompile time. We therefore need to restrict this to v1.10.