### PR TITLE
Limit varargs `reshape` method to integer `AbstractUnitRange`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.14.2"
+version = "1.15.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -348,7 +348,9 @@ _similar_axes_or_length(A, T, ax::I, ::I) where {I} = similar(A, T, map(_indexle
 _similar_axes_or_length(AT, ax::I, ::I) where {I} = similar(AT, map(_indexlength, ax))
 
 # reshape accepts a single colon
-Base.reshape(A::AbstractArray, inds::OffsetAxis...) = reshape(A, inds)
+# this method is limited to AbstractUnitRange{<:Integer} to avoid method overwritten errors if Base defines the same,
+# see https://github.com/JuliaLang/julia/pull/56850
+Base.reshape(A::AbstractArray, inds::Union{Integer, Colon, AbstractUnitRange{<:Integer}}...) = reshape(A, inds)
 function Base.reshape(A::AbstractArray, inds::Tuple{Vararg{OffsetAxis}})
     AR = reshape(no_offset_view(A), map(_indexlength, inds))
     O = OffsetArray(AR, map(_offset, axes(AR), inds))


### PR DESCRIPTION
This is a hacky workaround for the error seen in  https://github.com/JuliaLang/julia/pull/56850. The idea is to move the method to `Base`, but this can't be done without precompilation errors. We therefore narrow this method, so that the `Base` method may be added safely before this method is version-limited in this package.