### PR TITLE
Remove unnecessary `reshape` methods

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -376,16 +376,9 @@ _reshape2(A::OffsetArray, inds) = reshape(parent(A), inds)
 _reshape_nov(A, inds) = _reshape(no_offset_view(A), inds)
 
 # And for non-offset axes, we can just return a reshape of the parent directly
-Base.reshape(A::OffsetArray, inds::Tuple{Union{Integer,Base.OneTo},Vararg{Union{Integer,Base.OneTo}}}) = _reshape_nov(A, inds)
 Base.reshape(A::OffsetArray, inds::Dims) = _reshape_nov(A, inds)
-Base.reshape(A::OffsetVector, ::Colon) = A
 Base.reshape(A::OffsetVector, ::Tuple{Colon}) = A
-Base.reshape(A::OffsetArray, inds::Union{Int,Colon}...) = reshape(A, inds)
 Base.reshape(A::OffsetArray, inds::Tuple{Vararg{Union{Int,Colon}}}) = _reshape_nov(A, inds)
-# The following two additional methods for Colon are added to resolve method ambiguities to
-# Base: https://github.com/JuliaLang/julia/pull/45387#issuecomment-1132859663
-Base.reshape(A::OffsetArray, inds::Colon) = reshape(parent(A), inds)
-Base.reshape(A::OffsetArray, inds::Tuple{Colon}) = reshape(parent(A), inds)
 
 # permutedims in Base does not preserve axes, and can not be fixed in a non-breaking way
 # This is a stopgap solution


### PR DESCRIPTION
Tests appear to pass without these as well, as these cases are handled correctly by the fallback methods.